### PR TITLE
Trackscheme thumbnails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>8.0.0</version>
+		<version>15.7.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/SpotIconGrabber.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/SpotIconGrabber.java
@@ -26,7 +26,7 @@ import fiji.plugin.trackmate.util.TMUtils;
  * This class is used to take a snapshot of a {@link Spot} object (or
  * collection) from its coordinates and an {@link ImagePlus} that contain the
  * pixel data.
- * 
+ *
  * @author Jean-Yves Tinevez <jeanyves.tinevez@gmail.com> - Dec 2010 - 2014
  */
 public class SpotIconGrabber< T extends RealType< T >>
@@ -44,13 +44,19 @@ public class SpotIconGrabber< T extends RealType< T >>
 	 * radius coordinates are used to get a location on the image given at
 	 * construction. Physical coordinates are transformed in pixel coordinates
 	 * thanks to the calibration stored in the {@link ImgPlus}.
+	 *
+	 * @param spot
+	 *            the spot to generate a thumbnail image from.
+	 * @param radiusFactor
+	 *            a factor that determines the size of the thumbnail. The
+	 *            thumbnail will have a size equal to the spot diameter times
+	 *            this radius.
 	 */
-	public String getImageString( final Spot spot )
+	public String getImageString( final Spot spot, final double radiusFactor )
 	{
 		// Get crop coordinates
 		final double[] calibration = TMUtils.getSpatialCalibration( img );
-		final double radius = spot.getFeature( Spot.RADIUS ); // physical units,
-																// REQUIRED!
+		final double radius = spot.getFeature( Spot.RADIUS ) * radiusFactor;
 		final long x = Math.round( ( spot.getFeature( Spot.POSITION_X ) - radius ) / calibration[ 0 ] );
 		final long y = Math.round( ( spot.getFeature( Spot.POSITION_Y ) - radius ) / calibration[ 1 ] );
 		final long width = Math.max( 1, Math.round( 2 * radius / calibration[ 0 ] ) );

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/SpotImageUpdater.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/SpotImageUpdater.java
@@ -10,48 +10,71 @@ import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.util.TMUtils;
 
-public class SpotImageUpdater {
-	
+public class SpotImageUpdater
+{
+
 	private Integer previousFrame;
-	private SpotIconGrabber<?> grabber;
+
+	private SpotIconGrabber< ? > grabber;
+
 	private final Settings settings;
 
-	public SpotImageUpdater(final Settings settings) {
+	/**
+	 * Instantiates a new spot image updater.
+	 *
+	 * @param settings
+	 *            the {@link Settings} object from which we read the raw image
+	 *            and the target channel.
+	 */
+	public SpotImageUpdater( final Settings settings )
+	{
 		this.settings = settings;
 		this.previousFrame = -1;
 	}
 
 	/**
-	 * @return the image string of the given spot, based on the raw images contained in the given model.
-	 * For performance, the image at target frame is stored for subsequent calls of this method. 
-	 * So it is a good idea to group calls to this method for spots that belong to the
-	 * same frame.
+	 * Returns the image string of the given spot, based on the raw images
+	 * contained in the given model. For performance, the image at target frame
+	 * is stored for subsequent calls of this method. So it is a good idea to
+	 * group calls to this method for spots that belong to the same frame.
+	 *
+	 * @param radiusFactor
+	 *            a factor that determines the size of the thumbnail. The
+	 *            thumbnail will have a size equal to the spot diameter times
+	 *            this radius.
+	 * @return the image string.
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public String getImageString(final Spot spot) {
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public String getImageString( final Spot spot, final double radiusFactor )
+	{
 
-		Integer frame = spot.getFeature(Spot.FRAME).intValue();
-		if (null == frame)
+		final Integer frame = spot.getFeature( Spot.FRAME ).intValue();
+		if ( null == frame )
 			return "";
-		if (frame == previousFrame) {
+		if ( frame == previousFrame )
+		{
 			// Keep the same image than in memory
-		} else {
-			ImgPlus img = TMUtils.rawWraps(settings.imp);
+		}
+		else
+		{
+			final ImgPlus img = TMUtils.rawWraps( settings.imp );
 			int targetChannel = 0;
-			if (settings != null && settings.detectorSettings != null) {
+			if ( settings != null && settings.detectorSettings != null )
+			{
 				// Try to extract it from detector settings target channel
-				Map<String, Object> ds = settings.detectorSettings;
-				Object obj = ds.get(KEY_TARGET_CHANNEL);
-				if (null != obj && obj instanceof Integer) {
-					targetChannel = ((Integer) obj) - 1;
+				final Map< String, Object > ds = settings.detectorSettings;
+				final Object obj = ds.get( KEY_TARGET_CHANNEL );
+				if ( null != obj && obj instanceof Integer )
+				{
+					targetChannel = ( ( Integer ) obj ) - 1;
 				}
 			} // TODO: be more flexible about that
-			ImgPlus<?> imgCT = HyperSliceImgPlus.fixTimeAxis( 
-					HyperSliceImgPlus.fixChannelAxis(img, targetChannel), 
-					frame);
-			grabber = new SpotIconGrabber(imgCT);
+			final ImgPlus< ? > imgCT = HyperSliceImgPlus.fixTimeAxis(
+					HyperSliceImgPlus.fixChannelAxis( img, targetChannel ),
+					frame );
+			grabber = new SpotIconGrabber( imgCT );
 			previousFrame = frame;
 		}
-		return grabber.getImageString(spot);			
+		return grabber.getImageString( spot, radiusFactor );
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
@@ -1,26 +1,5 @@
 package fiji.plugin.trackmate.visualization.trackscheme;
 
-import com.mxgraph.model.mxCell;
-import com.mxgraph.model.mxGeometry;
-import com.mxgraph.model.mxICell;
-import com.mxgraph.model.mxIGraphModel;
-import com.mxgraph.util.mxCellRenderer;
-import com.mxgraph.util.mxConstants;
-import com.mxgraph.util.mxEvent;
-import com.mxgraph.util.mxEventObject;
-import com.mxgraph.util.mxEventSource.mxIEventListener;
-import com.mxgraph.util.mxRectangle;
-import com.mxgraph.util.mxStyleUtils;
-import com.mxgraph.view.mxGraphSelectionModel;
-
-import fiji.plugin.trackmate.Model;
-import fiji.plugin.trackmate.ModelChangeEvent;
-import fiji.plugin.trackmate.SelectionChangeEvent;
-import fiji.plugin.trackmate.SelectionModel;
-import fiji.plugin.trackmate.Spot;
-import fiji.plugin.trackmate.visualization.AbstractTrackMateModelView;
-import fiji.plugin.trackmate.visualization.TrackColorGenerator;
-import fiji.plugin.trackmate.visualization.TrackMateModelView;
 import ij.ImagePlus;
 
 import java.awt.Color;
@@ -45,6 +24,27 @@ import javax.swing.JViewport;
 import javax.swing.SwingUtilities;
 
 import org.jgrapht.graph.DefaultWeightedEdge;
+
+import com.mxgraph.model.mxCell;
+import com.mxgraph.model.mxGeometry;
+import com.mxgraph.model.mxICell;
+import com.mxgraph.model.mxIGraphModel;
+import com.mxgraph.util.mxCellRenderer;
+import com.mxgraph.util.mxConstants;
+import com.mxgraph.util.mxEvent;
+import com.mxgraph.util.mxEventObject;
+import com.mxgraph.util.mxEventSource.mxIEventListener;
+import com.mxgraph.util.mxRectangle;
+import com.mxgraph.util.mxStyleUtils;
+import com.mxgraph.view.mxGraphSelectionModel;
+
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.ModelChangeEvent;
+import fiji.plugin.trackmate.SelectionChangeEvent;
+import fiji.plugin.trackmate.SelectionModel;
+import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.visualization.AbstractTrackMateModelView;
+import fiji.plugin.trackmate.visualization.TrackColorGenerator;
 
 public class TrackScheme extends AbstractTrackMateModelView
 {
@@ -282,11 +282,12 @@ public class TrackScheme extends AbstractTrackMateModelView
 			}
 			if ( null == cell )
 			{
-				// mxCell not present in graph. Most likely because the
-				// corresponding spot belonged
-				// to an invisible track, and a cell was not created for it when
-				// TrackScheme was
-				// launched. So we create one on the fly now.
+				/*
+				 * mxCell not present in graph. Most likely because the
+				 * corresponding spot belonged to an invisible track, and a cell
+				 * was not created for it when TrackScheme was launched. So we
+				 * create one on the fly now.
+				 */
 				final int row = getUnlaidSpotColumn();
 				cell = insertSpotInGraph( spot, row );
 				final int frame = spot.getFeature( Spot.FRAME ).intValue();
@@ -297,7 +298,8 @@ public class TrackScheme extends AbstractTrackMateModelView
 			if ( spotImageUpdater != null && doThumbnailCapture )
 			{
 				String style = cell.getStyle();
-				final String imageStr = spotImageUpdater.getImageString( spot );
+				final double radiusFactor = ( Double ) displaySettings.get( KEY_SPOT_RADIUS_RATIO );
+				final String imageStr = spotImageUpdater.getImageString( spot, radiusFactor );
 				style = mxStyleUtils.setStyle( style, mxConstants.STYLE_IMAGE, "data:image/base64," + imageStr );
 				graph.getModel().setStyle( cell, style );
 			}
@@ -331,9 +333,10 @@ public class TrackScheme extends AbstractTrackMateModelView
 		final mxGeometry geometry = new mxGeometry( x, y, DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT );
 		cellAdded.setGeometry( geometry );
 		// Set its style
+		final double radiusFactor = ( Double ) displaySettings.get( KEY_SPOT_RADIUS_RATIO );
 		if ( null != spotImageUpdater && doThumbnailCapture )
 		{
-			final String imageStr = spotImageUpdater.getImageString( spot );
+			final String imageStr = spotImageUpdater.getImageString( spot, radiusFactor );
 			graph.getModel().setStyle( cellAdded, mxConstants.STYLE_IMAGE + "=" + "data:image/base64," + imageStr );
 		}
 		return cellAdded;
@@ -778,7 +781,7 @@ public class TrackScheme extends AbstractTrackMateModelView
 	@Override
 	public void setDisplaySettings( final String key, final Object value )
 	{
-		if ( key == TrackMateModelView.KEY_TRACK_COLORING )
+		if ( key == KEY_TRACK_COLORING )
 		{
 			if ( null != stylist )
 			{
@@ -789,6 +792,10 @@ public class TrackScheme extends AbstractTrackMateModelView
 				doTrackStyle();
 				refresh();
 			}
+		}
+		else if ( key == KEY_SPOT_RADIUS_RATIO )
+		{
+			thumbnailCaptured = false;
 		}
 		displaySettings.put( key, value );
 	}
@@ -1251,6 +1258,7 @@ public class TrackScheme extends AbstractTrackMateModelView
 		if ( null != spotImageUpdater )
 		{
 			gui.logger.setStatus( "Collecting spot thumbnails." );
+			final double radiusFactor = ( Double ) displaySettings.get( KEY_SPOT_RADIUS_RATIO );
 			int index = 0;
 			try
 			{
@@ -1263,7 +1271,7 @@ public class TrackScheme extends AbstractTrackMateModelView
 					{
 
 						final mxICell cell = graph.getCellFor( spot );
-						final String imageStr = spotImageUpdater.getImageString( spot );
+						final String imageStr = spotImageUpdater.getImageString( spot, radiusFactor );
 						String style = cell.getStyle();
 						style = mxStyleUtils.setStyle( style, mxConstants.STYLE_IMAGE, "data:image/base64," + imageStr );
 						graph.getModel().setStyle( cell, style );


### PR DESCRIPTION
TrackScheme acknowledges the radius-ratio setting  when capturing spot thumbnails.
So to get a thumbnail in TrackScheme that has a larger FOV, simply set a larger radius ratio in te GUI 'Configure view' panel and regenerate thumbnails. 