### PR TITLE
Introducing new Action for closing gaps in tracks

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
@@ -1,0 +1,157 @@
+package fiji.plugin.trackmate.action;
+
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.SpotCollection;
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.gui.TrackMateGUIController;
+import fiji.plugin.trackmate.gui.TrackMateWizard;
+import ij.gui.WaitForUserDialog;
+import net.imglib2.RealPoint;
+import org.scijava.plugin.Plugin;
+
+import javax.swing.*;
+import java.util.Set;
+
+/**
+ * This action allows to close gaps in tracks by creating new intermediate spots which are located at interpolated positions.
+ * This is useful if you want to measure signal intensity changing during time, even if the spot is not visible. Thus, trackmate
+ * is utilisable for Fluorescence Recovery after Photobleaching (FRAP) analysis.
+ *
+ * Author: Robert Haase, Scientific Computing Facility, MPI-CBG, rhaase@mpi-cbg.de
+ *
+ * Date: June 2016
+ *
+ */
+public class CloseGapsByLinearInterpolationAction extends AbstractTMAction {
+
+
+    public static final ImageIcon ICON = new ImageIcon(TrackMateWizard.class.getResource("images/spot_icon.png"));
+    public static final String NAME = "Close gaps by introducing new spots";
+
+    public static final String KEY = "CLOSE_GAPS_BY_LINEAR_INPERPOLATION";
+    public static final String INFO_TEXT = "<html>" +
+            "This action closes gaps in tracks by introducing new spots. The spots positions and size are calculated using linear interpolation." +
+            "</html>";
+
+    @Override
+    public void execute(final TrackMate trackmate) {
+        final Model model = trackmate.getModel();
+
+
+        Set<Integer> trackIDs = model.getTrackModel().trackIDs(true);
+
+        // go through all tracks
+        for (Integer trackID : trackIDs)
+        {
+            Set<Spot> spots = model.getTrackModel().trackSpots(trackID);
+            if (spots != null) {
+                model.beginUpdate();
+
+                // go through all spots, search for gaps
+                for (Spot currentSpot : spots) {
+                    int currentFrame = currentSpot.getFeatures().get("FRAME").intValue();
+
+                    Spot nextSpot = null;
+                    int nextFrame = 0;
+
+                    // find the next following spot
+                    for (Spot futureSpot : spots) {
+                        int futureFrame = futureSpot.getFeatures().get("FRAME").intValue();
+                        if (futureFrame > currentFrame) {
+                            if (nextSpot == null || nextFrame > futureFrame) {
+                                nextSpot = futureSpot;
+                                nextFrame = futureFrame;
+                            }
+                        }
+                    }
+
+                    // if a following spot was found and there is a gap between current and next
+                    if (nextSpot != null && (nextFrame - currentFrame > 1)) {
+
+                        double[] currentPosition = new double[3];
+                        double[] nextPosition = new double[3];
+
+                        nextSpot.localize(nextPosition);
+                        currentSpot.localize(currentPosition);
+
+                        model.removeEdge(currentSpot, nextSpot);
+
+                        Spot formerSpot = currentSpot;
+                        for (int f = currentFrame + 1; f < nextFrame; f++) {
+                            double weight = (double) (nextFrame - f) / (nextFrame - currentFrame);
+
+
+                            double[] position = new double[3];
+                            for (int d = 0; d < currentSpot.numDimensions(); d++) {
+                                position[d] = weight * currentPosition[d] + (1.0 - weight) * nextPosition[d];
+                            }
+
+                            RealPoint rp = new RealPoint(position);
+
+                            Spot newSpot = new Spot(rp, 0, 0);
+
+                            // Set some properties of the new spot
+                            interpolateFeature(newSpot, currentSpot, nextSpot, weight, "RADIUS");
+                            interpolateFeature(newSpot, currentSpot, nextSpot, weight, "QUALITY");
+                            interpolateFeature(newSpot, currentSpot, nextSpot, weight, "POSITION_T");
+                            newSpot.getFeatures().put("TRACK_ID", trackID.doubleValue());
+                            newSpot.getFeatures().put("FRAME", (double) f);
+
+                            model.addSpotTo(newSpot, f);
+                            model.addEdge(formerSpot, newSpot, 1.0);
+                            formerSpot = newSpot;
+                        }
+                    }
+                }
+                model.endUpdate();
+            }
+        }
+    }
+
+    private void interpolateFeature(Spot targetSpot, Spot spot1, Spot spot2, double weight, String feature)
+    {
+        if  (targetSpot.getFeatures().containsKey(feature)) {
+            targetSpot.getFeatures().remove(feature);
+        }
+
+        targetSpot.getFeatures().put(feature, weight * spot1.getFeature(feature) + (1.0 - weight) * spot2.getFeature(feature));
+    }
+
+
+    @Plugin( type = TrackMateActionFactory.class )
+    public static class Factory implements TrackMateActionFactory
+    {
+
+        @Override
+        public String getInfoText()
+        {
+            return INFO_TEXT;
+        }
+
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public String getKey()
+        {
+            return KEY;
+        }
+
+        @Override
+        public ImageIcon getIcon()
+        {
+            return ICON;
+        }
+
+        @Override
+        public TrackMateAction create( final TrackMateGUIController controller )
+        {
+            return new CloseGapsByLinearInterpolationAction();
+        }
+    }
+
+}

--- a/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
@@ -13,134 +13,145 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * This action allows to close gaps in tracks by creating new intermediate spots which are located at interpolated positions.
- * This is useful if you want to measure signal intensity changing during time, even if the spot is not visible. Thus, trackmate
- * is utilisable for Fluorescence Recovery after Photobleaching (FRAP) analysis.
+ * This action allows to close gaps in tracks by creating new intermediate spots
+ * which are located at interpolated positions. This is useful if you want to
+ * measure signal intensity changing during time, even if the spot is not
+ * visible. Thus, trackmate is utilisable for Fluorescence Recovery after
+ * Photobleaching (FRAP) analysis.
  *
- * Author: Robert Haase, Scientific Computing Facility, MPI-CBG, rhaase@mpi-cbg.de
+ * Author: Robert Haase, Scientific Computing Facility, MPI-CBG,
+ * rhaase@mpi-cbg.de
  *
  * Date: June 2016
  *
  */
-public class CloseGapsByLinearInterpolationAction extends AbstractTMAction {
+public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
+{
 
+	public static final ImageIcon ICON = new ImageIcon( TrackMateWizard.class.getResource( "images/spot_icon.png" ) );
 
-    public static final ImageIcon ICON = new ImageIcon(TrackMateWizard.class.getResource("images/spot_icon.png"));
-    public static final String NAME = "Close gaps by introducing new spots";
+	public static final String NAME = "Close gaps by introducing new spots";
 
-    public static final String KEY = "CLOSE_GAPS_BY_LINEAR_INPERPOLATION";
-    public static final String INFO_TEXT = "<html>" +
-            "This action closes gaps in tracks by introducing new spots. The spots positions and size are calculated using linear interpolation." +
-            "</html>";
+	public static final String KEY = "CLOSE_GAPS_BY_LINEAR_INPERPOLATION";
 
-    @Override
-    public void execute(final TrackMate trackmate) {
-        final Model model = trackmate.getModel();
+	public static final String INFO_TEXT = "<html>" +
+			"This action closes gaps in tracks by introducing new spots. The spots positions and size are calculated using linear interpolation." +
+			"</html>";
 
-        TrackModel trackModel = model.getTrackModel();
+	@Override
+	public void execute( final TrackMate trackmate )
+	{
+		final Model model = trackmate.getModel();
 
-        boolean changed = true;
+		TrackModel trackModel = model.getTrackModel();
 
-        while (changed) {
-            changed = false;
+		boolean changed = true;
 
-            Set<DefaultWeightedEdge> edges = model.getTrackModel().edgeSet();
-            for (DefaultWeightedEdge edge : edges) {
-                Spot currentSpot = trackModel.getEdgeSource(edge);
-                Spot nextSpot = trackModel.getEdgeTarget(edge);
+		while ( changed )
+		{
+			changed = false;
 
-                int currentFrame = currentSpot.getFeature(Spot.FRAME).intValue();
-                int nextFrame = nextSpot.getFeature(Spot.FRAME).intValue();
+            // Got through all edges, check if the frame distance between spots is larger than 1
+			Set< DefaultWeightedEdge > edges = model.getTrackModel().edgeSet();
+			for ( DefaultWeightedEdge edge : edges )
+			{
+				Spot currentSpot = trackModel.getEdgeSource( edge );
+				Spot nextSpot = trackModel.getEdgeTarget( edge );
 
-                if (nextSpot != null && (nextFrame - currentFrame > 1)) {
-                    model.beginUpdate();
+				int currentFrame = currentSpot.getFeature( Spot.FRAME ).intValue();
+				int nextFrame = nextSpot.getFeature( Spot.FRAME ).intValue();
 
-                    double[] currentPosition = new double[3];
-                    double[] nextPosition = new double[3];
+				if ( nextSpot != null && ( nextFrame - currentFrame > 1 ) )
+				{
+					model.beginUpdate();
 
-                    nextSpot.localize(nextPosition);
-                    currentSpot.localize(currentPosition);
+					double[] currentPosition = new double[ 3 ];
+					double[] nextPosition = new double[ 3 ];
 
-                    model.removeEdge(currentSpot, nextSpot);
+					nextSpot.localize( nextPosition );
+					currentSpot.localize( currentPosition );
 
-                    Spot formerSpot = currentSpot;
-                    for (int f = currentFrame + 1; f < nextFrame; f++) {
-                        double weight = (double) (nextFrame - f) / (nextFrame - currentFrame);
+					model.removeEdge( currentSpot, nextSpot );
 
+                    // create new spots in between; interpolate coordinates and some features
+					Spot formerSpot = currentSpot;
+					for ( int f = currentFrame + 1; f < nextFrame; f++ )
+					{
+						double weight = ( double ) ( nextFrame - f ) / ( nextFrame - currentFrame );
 
-                        double[] position = new double[3];
-                        for (int d = 0; d < currentSpot.numDimensions(); d++) {
-                            position[d] = weight * currentPosition[d] + (1.0 - weight) * nextPosition[d];
-                        }
+						double[] position = new double[ 3 ];
+						for ( int d = 0; d < currentSpot.numDimensions(); d++ )
+						{
+							position[ d ] = weight * currentPosition[ d ] + ( 1.0 - weight ) * nextPosition[ d ];
+						}
 
-                        RealPoint rp = new RealPoint(position);
+						RealPoint rp = new RealPoint( position );
 
-                        Spot newSpot = new Spot(rp, 0, 0);
+						Spot newSpot = new Spot( rp, 0, 0 );
 
-                        // Set some properties of the new spot
-                        interpolateFeature(newSpot, currentSpot, nextSpot, weight, "RADIUS");
-                        interpolateFeature(newSpot, currentSpot, nextSpot, weight, "QUALITY");
-                        interpolateFeature(newSpot, currentSpot, nextSpot, weight, "POSITION_T");
-                        newSpot.getFeatures().put("FRAME", (double) f);
+						// Set some properties of the new spot
+						interpolateFeature( newSpot, currentSpot, nextSpot, weight, Spot.RADIUS );
+						interpolateFeature( newSpot, currentSpot, nextSpot, weight, Spot.QUALITY );
+						interpolateFeature( newSpot, currentSpot, nextSpot, weight, Spot.POSITION_T );
 
-                        model.addSpotTo(newSpot, f);
-                        model.addEdge(formerSpot, newSpot, 1.0);
-                        formerSpot = newSpot;
-                    }
-                    model.addEdge(formerSpot, nextSpot, 1.0);
-                    model.endUpdate();
+						model.addSpotTo( newSpot, f );
+						model.addEdge( formerSpot, newSpot, 1.0 );
+						formerSpot = newSpot;
+					}
+					model.addEdge( formerSpot, nextSpot, 1.0 );
+					model.endUpdate();
 
-                    changed = true;
-                    break;
-                }
-            }
-        }
-    }
+                    // Restart search to prevent ConcurrentModificationException
+					changed = true;
+					break;
+				}
+			}
+		}
+	}
 
+	private void interpolateFeature( Spot targetSpot, Spot spot1, Spot spot2, double weight, String feature )
+	{
+		if ( targetSpot.getFeatures().containsKey( feature ) )
+		{
+			targetSpot.getFeatures().remove( feature );
+		}
 
-    private void interpolateFeature(Spot targetSpot, Spot spot1, Spot spot2, double weight, String feature)
-    {
-        if  (targetSpot.getFeatures().containsKey(feature)) {
-            targetSpot.getFeatures().remove(feature);
-        }
+		targetSpot.getFeatures().put( feature, weight * spot1.getFeature( feature ) + ( 1.0 - weight ) * spot2.getFeature( feature ) );
+	}
 
-        targetSpot.getFeatures().put(feature, weight * spot1.getFeature(feature) + (1.0 - weight) * spot2.getFeature(feature));
-    }
+	@Plugin( type = TrackMateActionFactory.class )
+	public static class Factory implements TrackMateActionFactory
+	{
 
+		@Override
+		public String getInfoText()
+		{
+			return INFO_TEXT;
+		}
 
-    @Plugin( type = TrackMateActionFactory.class )
-    public static class Factory implements TrackMateActionFactory
-    {
+		@Override
+		public String getName()
+		{
+			return NAME;
+		}
 
-        @Override
-        public String getInfoText()
-        {
-            return INFO_TEXT;
-        }
+		@Override
+		public String getKey()
+		{
+			return KEY;
+		}
 
-        @Override
-        public String getName()
-        {
-            return NAME;
-        }
+		@Override
+		public ImageIcon getIcon()
+		{
+			return ICON;
+		}
 
-        @Override
-        public String getKey()
-        {
-            return KEY;
-        }
-
-        @Override
-        public ImageIcon getIcon()
-        {
-            return ICON;
-        }
-
-        @Override
-        public TrackMateAction create( final TrackMateGUIController controller )
-        {
-            return new CloseGapsByLinearInterpolationAction();
-        }
-    }
+		@Override
+		public TrackMateAction create( final TrackMateGUIController controller )
+		{
+			return new CloseGapsByLinearInterpolationAction();
+		}
+	}
 
 }

--- a/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
@@ -62,8 +62,10 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 				int currentFrame = currentSpot.getFeature( Spot.FRAME ).intValue();
 				int nextFrame = nextSpot.getFeature( Spot.FRAME ).intValue();
 
-				if ( nextSpot != null && ( nextFrame - currentFrame > 1 ) )
+				if ( nextSpot != null && ( Math.abs( nextFrame - currentFrame ) > 1 ) )
 				{
+					int presign = nextFrame > currentFrame ? 1 : -1;
+
 					model.beginUpdate();
 
 					double[] currentPosition = new double[ 3 ];
@@ -77,7 +79,7 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 					// create new spots in between; interpolate coordinates and
 					// some features
 					Spot formerSpot = currentSpot;
-					for ( int f = currentFrame + 1; f < nextFrame; f++ )
+					for ( int f = currentFrame + presign; ( f < nextFrame && presign == 1 ) || ( f > nextFrame && presign == -1 ); f += presign )
 					{
 						double weight = ( double ) ( nextFrame - f ) / ( nextFrame - currentFrame );
 

--- a/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationAction.java
@@ -51,7 +51,8 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 		{
 			changed = false;
 
-            // Got through all edges, check if the frame distance between spots is larger than 1
+			// Got through all edges, check if the frame distance between spots
+			// is larger than 1
 			Set< DefaultWeightedEdge > edges = model.getTrackModel().edgeSet();
 			for ( DefaultWeightedEdge edge : edges )
 			{
@@ -73,7 +74,8 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 
 					model.removeEdge( currentSpot, nextSpot );
 
-                    // create new spots in between; interpolate coordinates and some features
+					// create new spots in between; interpolate coordinates and
+					// some features
 					Spot formerSpot = currentSpot;
 					for ( int f = currentFrame + 1; f < nextFrame; f++ )
 					{
@@ -101,7 +103,7 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 					model.addEdge( formerSpot, nextSpot, 1.0 );
 					model.endUpdate();
 
-                    // Restart search to prevent ConcurrentModificationException
+					// Restart search to prevent ConcurrentModificationException
 					changed = true;
 					break;
 				}

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -1,0 +1,150 @@
+package fiji.plugin.trackmate.action;
+
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.TrackModel;
+import ij.plugin.frame.SyncWindows;
+import net.imglib2.RealPoint;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.traverse.GraphIterator;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Author: Robert Haase, Scientific Computing Facility, MPI-CBG,
+ * rhaase@mpi-cbg.de
+ *
+ * Date: June 2016
+ */
+public class CloseGapsByLinearInterpolationActionTest
+{
+	@Test
+	public void testIfGapsInLinearTracksAreClosed()
+	{
+		TrackMate trackmate = new TrackMate();
+
+        // Build a linear track with no division but a gap between spots
+		final Model model = trackmate.getModel();
+		model.beginUpdate();
+
+		Spot spot0 = createSpot( 0, 0, 0 );
+		Spot spot1 = createSpot( 1, 1, 0 );
+		Spot spot2 = createSpot( 2, 2, 0 );
+		Spot spot5 = createSpot( 5, 5, 0 );
+
+		model.addSpotTo( spot0, 0 );
+		model.addSpotTo( spot1, 1 );
+		model.addSpotTo( spot2, 2 );
+		model.addSpotTo( spot5, 5 );
+
+		model.addEdge( spot0, spot1, 1.0 );
+		model.addEdge( spot1, spot2, 1.0 );
+		model.addEdge( spot2, spot5, 1.0 );
+
+		model.endUpdate();
+
+        // close gap
+		CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		cgblia.execute( trackmate );
+
+		TrackModel trackModel = model.getTrackModel();
+
+        // Check if positions were interpolated in the right way
+		GraphIterator< Spot, DefaultWeightedEdge > spots = trackModel.getDepthFirstIterator( spot0, true );
+
+		double[][] referencePositions =
+				{
+						{ 0, 0 },
+						{ 1, 1 },
+						{ 2, 2 },
+						{ 3, 3 },
+						{ 4, 4 },
+						{ 5, 5 }
+				};
+
+		checkPositions( spots, referencePositions );
+	}
+
+	@Test
+	public void testIfGapsInDividingTracksAreClosed()
+	{
+		TrackMate trackmate = new TrackMate();
+
+        // Build a linear track with a division and a gap between spots
+		final Model model = trackmate.getModel();
+		model.beginUpdate();
+
+		Spot spot0 = createSpot( 0, 0, 0 );
+		Spot spot1 = createSpot( 1, 1, 0 );
+		Spot spot2 = createSpot( 2, 2, 0 );
+		Spot spot5a = createSpot( 5, 5, 0 );
+		Spot spot5b = createSpot( 8, 8, 0 );
+
+		model.addSpotTo( spot0, 0 );
+		model.addSpotTo( spot1, 1 );
+		model.addSpotTo( spot2, 2 );
+		model.addSpotTo( spot5a, 5 );
+		model.addSpotTo( spot5b, 5 );
+
+		model.addEdge( spot0, spot1, 1.0 );
+		model.addEdge( spot1, spot2, 1.0 );
+		model.addEdge( spot2, spot5a, 1.0 );
+		model.addEdge( spot2, spot5b, 1.0 );
+
+		model.endUpdate();
+
+        // close gaps
+		CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		cgblia.execute( trackmate );
+
+		TrackModel trackModel = model.getTrackModel();
+
+        // Check if positions were interpolated in the right way
+		GraphIterator< Spot, DefaultWeightedEdge > spots = trackModel.getDepthFirstIterator( spot0, true );
+
+		double[][] referencePositions =
+				{
+						{ 0, 0 },
+						{ 1, 1 },
+						{ 2, 2 },
+						{ 4, 4 },
+						{ 6, 6 },
+						{ 8, 8 },
+						{ 3, 3 },
+						{ 4, 4 },
+						{ 5, 5 }
+				};
+
+		checkPositions( spots, referencePositions );
+	}
+
+	private void checkPositions( GraphIterator< Spot, DefaultWeightedEdge > spots, double[][] referencePositions )
+	{
+
+		double tolerance = 0.00001;
+
+		int count = 0;
+		while ( spots.hasNext() )
+		{
+			Spot spot = spots.next();
+
+			assertTrue( "Position X is as expected ", Math.abs( referencePositions[ count ][ 0 ] - spot.getDoublePosition( 0 ) ) < tolerance );
+			assertTrue( "Position Y is as expected ", Math.abs( referencePositions[ count ][ 1 ] - spot.getDoublePosition( 1 ) ) < tolerance );
+
+			count++;
+		}
+
+	}
+
+	private Spot createSpot( double x, double y, double z )
+	{
+		Spot newSpot = new Spot( x, y, z, 1.0, 1.0 );
+
+		newSpot.getFeatures().put( Spot.POSITION_T, 1.0 );
+		return newSpot;
+	}
+}

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -122,7 +122,6 @@ public class CloseGapsByLinearInterpolationActionTest
 		checkPositions( spots, referencePositions );
 	}
 
-
 	@Test
 	public void testIfGapsInDividingBackwardsTracksAreClosed()
 	{
@@ -146,7 +145,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		model.addEdge( spot0, spot1, 1.0 );
 		model.addEdge( spot1, spot2, 1.0 );
-		model.addEdge(spot2, spot5a, 1.0);
+		model.addEdge( spot2, spot5a, 1.0 );
 		model.addEdge( spot2, spot5b, 1.0 );
 
 		model.endUpdate();

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -122,6 +122,60 @@ public class CloseGapsByLinearInterpolationActionTest
 		checkPositions( spots, referencePositions );
 	}
 
+
+	@Test
+	public void testIfGapsInDividingBackwardsTracksAreClosed()
+	{
+		TrackMate trackmate = new TrackMate();
+
+		// Build a linear track with a division and a gap between spots
+		final Model model = trackmate.getModel();
+		model.beginUpdate();
+
+		Spot spot0 = createSpot( 0, 0, 0 );
+		Spot spot1 = createSpot( 1, 1, 0 );
+		Spot spot2 = createSpot( 2, 2, 0 );
+		Spot spot5a = createSpot( 5, 5, 0 );
+		Spot spot5b = createSpot( 8, 8, 0 );
+
+		model.addSpotTo( spot0, 0 );
+		model.addSpotTo( spot1, 1 );
+		model.addSpotTo( spot2, 2 );
+		model.addSpotTo( spot5a, -1 );
+		model.addSpotTo( spot5b, -1 );
+
+		model.addEdge( spot0, spot1, 1.0 );
+		model.addEdge( spot1, spot2, 1.0 );
+		model.addEdge(spot2, spot5a, 1.0);
+		model.addEdge( spot2, spot5b, 1.0 );
+
+		model.endUpdate();
+
+		// close gaps
+		CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		cgblia.execute( trackmate );
+
+		TrackModel trackModel = model.getTrackModel();
+
+		// Check if positions were interpolated in the right way
+		GraphIterator< Spot, DefaultWeightedEdge > spots = trackModel.getDepthFirstIterator( spot0, false );
+
+		double[][] referencePositions =
+				{
+						{ 0, 0 },
+						{ 1, 1 },
+						{ 2, 2 },
+						{ 4, 4 },
+						{ 6, 6 },
+						{ 8, 8 },
+						{ 3, 3 },
+						{ 4, 4 },
+						{ 5, 5 }
+				};
+
+		checkPositions( spots, referencePositions );
+	}
+
 	private void checkPositions( GraphIterator< Spot, DefaultWeightedEdge > spots, double[][] referencePositions )
 	{
 

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -27,7 +27,7 @@ public class CloseGapsByLinearInterpolationActionTest
 	{
 		TrackMate trackmate = new TrackMate();
 
-        // Build a linear track with no division but a gap between spots
+		// Build a linear track with no division but a gap between spots
 		final Model model = trackmate.getModel();
 		model.beginUpdate();
 
@@ -47,13 +47,13 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		model.endUpdate();
 
-        // close gap
+		// close gap
 		CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
 		cgblia.execute( trackmate );
 
 		TrackModel trackModel = model.getTrackModel();
 
-        // Check if positions were interpolated in the right way
+		// Check if positions were interpolated in the right way
 		GraphIterator< Spot, DefaultWeightedEdge > spots = trackModel.getDepthFirstIterator( spot0, true );
 
 		double[][] referencePositions =
@@ -74,7 +74,7 @@ public class CloseGapsByLinearInterpolationActionTest
 	{
 		TrackMate trackmate = new TrackMate();
 
-        // Build a linear track with a division and a gap between spots
+		// Build a linear track with a division and a gap between spots
 		final Model model = trackmate.getModel();
 		model.beginUpdate();
 
@@ -97,13 +97,13 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		model.endUpdate();
 
-        // close gaps
+		// close gaps
 		CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
 		cgblia.execute( trackmate );
 
 		TrackModel trackModel = model.getTrackModel();
 
-        // Check if positions were interpolated in the right way
+		// Check if positions were interpolated in the right way
 		GraphIterator< Spot, DefaultWeightedEdge > spots = trackModel.getDepthFirstIterator( spot0, true );
 
 		double[][] referencePositions =


### PR DESCRIPTION
Hey guys,

we wanted to do FRAP analysis. Therefore, it is neccessary to measure the signal of a spot even in frames, when it is not visible. The trackers allow building tracks with gaps, but measurement of the signal in these gaps was not possible. Thus, I introduced the action in this pull request allowing our analysis by introducing new spots in the track at empty frames by interpolating the position before and after the gap. Hopefully it is useful for others.

Cheers,
Robert
