### PR TITLE
Add Viridis colormap

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/TrackMateOptionUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMateOptionUtils.java
@@ -1,0 +1,15 @@
+package fiji.plugin.trackmate;
+
+import org.scijava.Context;
+import org.scijava.options.OptionsService;
+
+import ij.IJ;
+
+public class TrackMateOptionUtils {
+	private TrackMateOptionUtils() {}
+
+	public static TrackMateOptions getOptions() {
+		Context ctx = (Context) IJ.runPlugIn("org.scijava.Context", "");
+		return ctx.getService(OptionsService.class).getOptions(TrackMateOptions.class);
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/TrackMateOptions.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMateOptions.java
@@ -1,0 +1,27 @@
+package fiji.plugin.trackmate;
+
+import org.jfree.chart.renderer.InterpolatePaintScale;
+import org.scijava.menu.MenuConstants;
+import org.scijava.options.OptionsPlugin;
+import org.scijava.plugin.Menu;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = OptionsPlugin.class, menu = {
+		@Menu(label = MenuConstants.EDIT_LABEL, weight = MenuConstants.EDIT_WEIGHT, mnemonic = MenuConstants.EDIT_MNEMONIC),
+		@Menu(label = "Options"), @Menu(label = "TrackMate...") })
+public class TrackMateOptions extends OptionsPlugin {
+
+	@Parameter(label = "Look-up table for scales", choices = { "Viridis", "Jet" })
+	private String lutChoice = "Viridis";
+
+	public InterpolatePaintScale getPaintScale() {
+		switch (lutChoice) {
+		case "Jet":
+			return InterpolatePaintScale.Jet;
+		case "Viridis":
+		default:
+			return InterpolatePaintScale.Viridis;
+		}
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/action/CopyOverlayAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CopyOverlayAction.java
@@ -1,6 +1,5 @@
 package fiji.plugin.trackmate.action;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_HIGHLIGHT_COLOR;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_SPOT_COLOR;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_TRACK_DISPLAY_DEPTH;
@@ -18,6 +17,7 @@ import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACK_D
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACK_DISPLAY_MODE;
 import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.features.edges.EdgeVelocityAnalyzer;
 import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 import fiji.plugin.trackmate.gui.DisplaySettingsEvent;
@@ -158,7 +158,7 @@ public class CopyOverlayAction extends AbstractTMAction
 							displaySettings.put( KEY_TRACK_DISPLAY_MODE, DEFAULT_TRACK_DISPLAY_MODE );
 							displaySettings.put( KEY_TRACK_DISPLAY_DEPTH, DEFAULT_TRACK_DISPLAY_DEPTH );
 							displaySettings.put( KEY_TRACK_COLORING, trackColorGenerator );
-							displaySettings.put( KEY_COLORMAP, DEFAULT_COLOR_MAP );
+							displaySettings.put( KEY_COLORMAP, TrackMateOptionUtils.getOptions().getPaintScale() );
 							guimodel.setDisplaySettings( displaySettings );
 
 							guimodel.addView( newDisplayer );

--- a/src/main/java/fiji/plugin/trackmate/features/AbstractFeatureGrapher.java
+++ b/src/main/java/fiji/plugin/trackmate/features/AbstractFeatureGrapher.java
@@ -1,9 +1,9 @@
 package fiji.plugin.trackmate.features;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.trackscheme.TrackScheme.TRACK_SCHEME_ICON;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.TrackModel;
 import fiji.plugin.trackmate.util.ExportableChartPanel;
 
@@ -31,7 +31,7 @@ public abstract class AbstractFeatureGrapher {
 	
 	protected static final Shape DEFAULT_SHAPE = new Ellipse2D.Double(-3, -3, 6, 6);
 
-	protected final InterpolatePaintScale paints = DEFAULT_COLOR_MAP; 
+	protected final InterpolatePaintScale paints = TrackMateOptionUtils.getOptions().getPaintScale(); 
 	protected final String xFeature;
 	protected final Set<String> yFeatures;
 	protected final Model model;

--- a/src/main/java/fiji/plugin/trackmate/features/AbstractFeatureGrapher.java
+++ b/src/main/java/fiji/plugin/trackmate/features/AbstractFeatureGrapher.java
@@ -1,5 +1,6 @@
 package fiji.plugin.trackmate.features;
 
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.trackscheme.TrackScheme.TRACK_SCHEME_ICON;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
@@ -30,7 +31,7 @@ public abstract class AbstractFeatureGrapher {
 	
 	protected static final Shape DEFAULT_SHAPE = new Ellipse2D.Double(-3, -3, 6, 6);
 
-	protected final InterpolatePaintScale paints = InterpolatePaintScale.Jet; 
+	protected final InterpolatePaintScale paints = DEFAULT_COLOR_MAP; 
 	protected final String xFeature;
 	protected final Set<String> yFeatures;
 	protected final Model model;

--- a/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
@@ -1,6 +1,5 @@
 package fiji.plugin.trackmate.gui;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_HIGHLIGHT_COLOR;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_SPOT_COLOR;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_TRACK_DISPLAY_DEPTH;
@@ -38,6 +37,7 @@ import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.action.AbstractTMAction;
 import fiji.plugin.trackmate.action.ExportAllSpotsStatsAction;
 import fiji.plugin.trackmate.action.ExportStatsToIJAction;
@@ -986,7 +986,7 @@ public class TrackMateGUIController implements ActionListener
 		displaySettings.put( KEY_TRACK_DISPLAY_MODE, DEFAULT_TRACK_DISPLAY_MODE );
 		displaySettings.put( KEY_TRACK_DISPLAY_DEPTH, DEFAULT_TRACK_DISPLAY_DEPTH );
 		displaySettings.put( KEY_TRACK_COLORING, trackColorGenerator );
-		displaySettings.put( KEY_COLORMAP, DEFAULT_COLOR_MAP );
+		displaySettings.put( KEY_COLORMAP, TrackMateOptionUtils.getOptions().getPaintScale() );
 		return displaySettings;
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/gui/panels/components/ColorByFeatureGUIPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/panels/components/ColorByFeatureGUIPanel.java
@@ -1,6 +1,13 @@
 package fiji.plugin.trackmate.gui.panels.components;
 
 import static fiji.plugin.trackmate.gui.TrackMateWizard.SMALL_FONT;
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.SpotCollection;
+import fiji.plugin.trackmate.features.manual.ManualEdgeColorAnalyzer;
+import fiji.plugin.trackmate.features.manual.ManualSpotColorAnalyzerFactory;
+import fiji.plugin.trackmate.gui.panels.ActionListenablePanel;
+import fiji.plugin.trackmate.visualization.MinMaxAdjustable;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -25,13 +32,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.jfree.chart.renderer.InterpolatePaintScale;
-
-import fiji.plugin.trackmate.Model;
-import fiji.plugin.trackmate.SpotCollection;
-import fiji.plugin.trackmate.features.manual.ManualEdgeColorAnalyzer;
-import fiji.plugin.trackmate.features.manual.ManualSpotColorAnalyzerFactory;
-import fiji.plugin.trackmate.gui.panels.ActionListenablePanel;
-import fiji.plugin.trackmate.visualization.MinMaxAdjustable;
 
 public class ColorByFeatureGUIPanel extends ActionListenablePanel implements MinMaxAdjustable
 {
@@ -89,7 +89,7 @@ public class ColorByFeatureGUIPanel extends ActionListenablePanel implements Min
 
 	private JComponent canvasColor;
 
-	protected InterpolatePaintScale colorMap = InterpolatePaintScale.Jet;
+	protected InterpolatePaintScale colorMap = DEFAULT_COLOR_MAP;
 
 	protected final Model model;
 

--- a/src/main/java/fiji/plugin/trackmate/gui/panels/components/ColorByFeatureGUIPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/panels/components/ColorByFeatureGUIPanel.java
@@ -1,9 +1,9 @@
 package fiji.plugin.trackmate.gui.panels.components;
 
 import static fiji.plugin.trackmate.gui.TrackMateWizard.SMALL_FONT;
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.SpotCollection;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.features.manual.ManualEdgeColorAnalyzer;
 import fiji.plugin.trackmate.features.manual.ManualSpotColorAnalyzerFactory;
 import fiji.plugin.trackmate.gui.panels.ActionListenablePanel;
@@ -89,7 +89,7 @@ public class ColorByFeatureGUIPanel extends ActionListenablePanel implements Min
 
 	private JComponent canvasColor;
 
-	protected InterpolatePaintScale colorMap = DEFAULT_COLOR_MAP;
+	protected InterpolatePaintScale colorMap = TrackMateOptionUtils.getOptions().getPaintScale();
 
 	protected final Model model;
 

--- a/src/main/java/fiji/plugin/trackmate/gui/panels/components/JPanelColorByFeatureGUI.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/panels/components/JPanelColorByFeatureGUI.java
@@ -1,6 +1,7 @@
 package fiji.plugin.trackmate.gui.panels.components;
 
 import static fiji.plugin.trackmate.gui.TrackMateWizard.SMALL_FONT;
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 
 import java.awt.BorderLayout;
 import java.awt.Canvas;
@@ -51,7 +52,7 @@ public class JPanelColorByFeatureGUI extends ActionListenablePanel
 
 	private JPanel jPanelColor;
 
-	protected InterpolatePaintScale colorMap = InterpolatePaintScale.Jet;
+	protected InterpolatePaintScale colorMap = DEFAULT_COLOR_MAP;
 
 	/*
 	 * DEFAULT VISIBILITY

--- a/src/main/java/fiji/plugin/trackmate/gui/panels/components/JPanelColorByFeatureGUI.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/panels/components/JPanelColorByFeatureGUI.java
@@ -1,7 +1,6 @@
 package fiji.plugin.trackmate.gui.panels.components;
 
 import static fiji.plugin.trackmate.gui.TrackMateWizard.SMALL_FONT;
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 
 import java.awt.BorderLayout;
 import java.awt.Canvas;
@@ -24,6 +23,7 @@ import javax.swing.JPanel;
 
 import org.jfree.chart.renderer.InterpolatePaintScale;
 
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.gui.panels.ActionListenablePanel;
 
@@ -52,7 +52,7 @@ public class JPanelColorByFeatureGUI extends ActionListenablePanel
 
 	private JPanel jPanelColor;
 
-	protected InterpolatePaintScale colorMap = DEFAULT_COLOR_MAP;
+	protected InterpolatePaintScale colorMap = TrackMateOptionUtils.getOptions().getPaintScale();
 
 	/*
 	 * DEFAULT VISIBILITY

--- a/src/main/java/fiji/plugin/trackmate/visualization/AbstractTrackMateModelView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/AbstractTrackMateModelView.java
@@ -6,6 +6,7 @@ import fiji.plugin.trackmate.SelectionChangeEvent;
 import fiji.plugin.trackmate.SelectionChangeListener;
 import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -115,7 +116,7 @@ public abstract class AbstractTrackMateModelView implements SelectionChangeListe
 		lDisplaySettings.put( KEY_TRACK_DISPLAY_MODE, DEFAULT_TRACK_DISPLAY_MODE );
 		lDisplaySettings.put( KEY_TRACK_DISPLAY_DEPTH, DEFAULT_TRACK_DISPLAY_DEPTH );
 		lDisplaySettings.put( KEY_TRACK_COLORING, new DummyTrackColorGenerator() );
-		lDisplaySettings.put( KEY_COLORMAP, DEFAULT_COLOR_MAP );
+		lDisplaySettings.put( KEY_COLORMAP, TrackMateOptionUtils.getOptions().getPaintScale() );
 		lDisplaySettings.put( KEY_LIMIT_DRAWING_DEPTH, DEFAULT_LIMIT_DRAWING_DEPTH );
 		lDisplaySettings.put( KEY_DRAWING_DEPTH, DEFAULT_DRAWING_DEPTH );
 		return lDisplaySettings;

--- a/src/main/java/fiji/plugin/trackmate/visualization/PerEdgeFeatureColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/PerEdgeFeatureColorGenerator.java
@@ -1,19 +1,20 @@
 package fiji.plugin.trackmate.visualization;
 
-import java.awt.Color;
-
-import org.jfree.chart.renderer.InterpolatePaintScale;
-import org.jgrapht.graph.DefaultWeightedEdge;
-
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.ModelChangeListener;
 import fiji.plugin.trackmate.features.manual.ManualEdgeColorAnalyzer;
 
+import java.awt.Color;
+
+import org.jfree.chart.renderer.InterpolatePaintScale;
+import org.jgrapht.graph.DefaultWeightedEdge;
+
 public class PerEdgeFeatureColorGenerator implements ModelChangeListener, TrackColorGenerator
 {
 
-	private static final InterpolatePaintScale generator = InterpolatePaintScale.Jet;
+	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
 
 	private final Model model;
 

--- a/src/main/java/fiji/plugin/trackmate/visualization/PerEdgeFeatureColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/PerEdgeFeatureColorGenerator.java
@@ -1,9 +1,9 @@
 package fiji.plugin.trackmate.visualization;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.ModelChangeListener;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.features.manual.ManualEdgeColorAnalyzer;
 
 import java.awt.Color;
@@ -14,7 +14,7 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 public class PerEdgeFeatureColorGenerator implements ModelChangeListener, TrackColorGenerator
 {
 
-	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
+	private InterpolatePaintScale generator;
 
 	private final Model model;
 
@@ -34,6 +34,7 @@ public class PerEdgeFeatureColorGenerator implements ModelChangeListener, TrackC
 	{
 		this.model = model;
 		model.addModelChangeListener( this );
+		generator = TrackMateOptionUtils.getOptions().getPaintScale();
 		setFeature( feature );
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
@@ -3,7 +3,14 @@
  */
 package fiji.plugin.trackmate.visualization;
 
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_TRACK_COLOR;
+import fiji.plugin.trackmate.FeatureModel;
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.ModelChangeEvent;
+import fiji.plugin.trackmate.ModelChangeListener;
+import fiji.plugin.trackmate.TrackModel;
+import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 
 import java.awt.Color;
 import java.util.HashMap;
@@ -12,13 +19,6 @@ import java.util.Set;
 
 import org.jfree.chart.renderer.InterpolatePaintScale;
 import org.jgrapht.graph.DefaultWeightedEdge;
-
-import fiji.plugin.trackmate.FeatureModel;
-import fiji.plugin.trackmate.Model;
-import fiji.plugin.trackmate.ModelChangeEvent;
-import fiji.plugin.trackmate.ModelChangeListener;
-import fiji.plugin.trackmate.TrackModel;
-import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 
 /**
  * A {@link TrackColorGenerator} that generate colors based on the whole track
@@ -30,7 +30,7 @@ import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 public class PerTrackFeatureColorGenerator implements TrackColorGenerator, ModelChangeListener
 {
 
-	private static final InterpolatePaintScale generator = InterpolatePaintScale.Jet;
+	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
 
 	private Map< Integer, Color > colorMap;
 

--- a/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
@@ -3,12 +3,12 @@
  */
 package fiji.plugin.trackmate.visualization;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_TRACK_COLOR;
 import fiji.plugin.trackmate.FeatureModel;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.ModelChangeListener;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.TrackModel;
 import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 
@@ -30,7 +30,7 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 public class PerTrackFeatureColorGenerator implements TrackColorGenerator, ModelChangeListener
 {
 
-	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
+	private InterpolatePaintScale generator;
 
 	private Map< Integer, Color > colorMap;
 
@@ -50,6 +50,7 @@ public class PerTrackFeatureColorGenerator implements TrackColorGenerator, Model
 	{
 		this.model = model;
 		model.addModelChangeListener( this );
+		generator = TrackMateOptionUtils.getOptions().getPaintScale();
 		setFeature( feature );
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/visualization/SpotColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/SpotColorGenerator.java
@@ -1,5 +1,6 @@
 package fiji.plugin.trackmate.visualization;
 
+import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.ModelChangeListener;
@@ -23,7 +24,7 @@ public class SpotColorGenerator implements FeatureColorGenerator< Spot >, ModelC
 
 	private boolean autoMode = true;
 
-	private static final InterpolatePaintScale generator = InterpolatePaintScale.Jet;
+	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
 
 	public SpotColorGenerator( final Model model )
 	{

--- a/src/main/java/fiji/plugin/trackmate/visualization/SpotColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/SpotColorGenerator.java
@@ -1,10 +1,10 @@
 package fiji.plugin.trackmate.visualization;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.ModelChangeListener;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 
 import java.awt.Color;
 import java.util.Set;
@@ -24,12 +24,13 @@ public class SpotColorGenerator implements FeatureColorGenerator< Spot >, ModelC
 
 	private boolean autoMode = true;
 
-	private static final InterpolatePaintScale generator = DEFAULT_COLOR_MAP;
+	private InterpolatePaintScale generator;
 
 	public SpotColorGenerator( final Model model )
 	{
 		this.model = model;
 		model.addModelChangeListener( this );
+		generator = TrackMateOptionUtils.getOptions().getPaintScale();
 	}
 
 	@Override

--- a/src/main/java/fiji/plugin/trackmate/visualization/TrackMateModelView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/TrackMateModelView.java
@@ -225,7 +225,7 @@ public interface TrackMateModelView
 	/**
 	 * The default color map.
 	 */
-	public static final InterpolatePaintScale DEFAULT_COLOR_MAP = InterpolatePaintScale.Jet;
+	public static final InterpolatePaintScale DEFAULT_COLOR_MAP = InterpolatePaintScale.Viridis;
 
 	/**
 	 * The default drawing depth, in image units.

--- a/src/main/java/fiji/plugin/trackmate/visualization/TrackMateModelView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/TrackMateModelView.java
@@ -7,12 +7,13 @@ import org.jfree.chart.renderer.InterpolatePaintScale;
 
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptions;
 
 public interface TrackMateModelView
 {
 
 	/*
-	 * KEY-VALUE CONSTANTS FOR LOOK & FILL CUSTOMIZATION
+	 * KEY-VALUE CONSTANTS FOR LOOK & FEEL CUSTOMIZATION
 	 */
 
 	/*
@@ -224,7 +225,11 @@ public interface TrackMateModelView
 
 	/**
 	 * The default color map.
+	 * 
+	 * @deprecated replaced by configurable {@code InterpolatePaintScale} provided
+	 *             by {@code TrackMateOptions}
 	 */
+	@Deprecated
 	public static final InterpolatePaintScale DEFAULT_COLOR_MAP = InterpolatePaintScale.Viridis;
 
 	/**

--- a/src/main/java/fiji/plugin/trackmate/visualization/hyperstack/FloatingDisplayConfigFrame.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/hyperstack/FloatingDisplayConfigFrame.java
@@ -1,6 +1,5 @@
 package fiji.plugin.trackmate.visualization.hyperstack;
 
-import static fiji.plugin.trackmate.visualization.TrackMateModelView.DEFAULT_COLOR_MAP;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_COLORMAP;
 
 import java.awt.BorderLayout;
@@ -12,6 +11,7 @@ import javax.swing.border.EmptyBorder;
 
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.features.edges.EdgeVelocityAnalyzer;
 import fiji.plugin.trackmate.features.track.TrackIndexAnalyzer;
 import fiji.plugin.trackmate.gui.DisplaySettingsEvent;
@@ -71,7 +71,7 @@ public class FloatingDisplayConfigFrame extends JFrame
 		if ( null != title )
 			panel.getTitleJLabel().setText( "Display options for " + title + "." );
 
-		displaySettings.put( KEY_COLORMAP, DEFAULT_COLOR_MAP );
+		displaySettings.put( KEY_COLORMAP, TrackMateOptionUtils.getOptions().getPaintScale() );
 		guimodel.setDisplaySettings( displaySettings );
 
 		guimodel.addView( view );

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
@@ -41,6 +41,7 @@ import fiji.plugin.trackmate.ModelChangeEvent;
 import fiji.plugin.trackmate.SelectionChangeEvent;
 import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMateOptionUtils;
 import fiji.plugin.trackmate.visualization.AbstractTrackMateModelView;
 import fiji.plugin.trackmate.visualization.TrackColorGenerator;
 import ij.ImagePlus;
@@ -879,7 +880,7 @@ public class TrackScheme extends AbstractTrackMateModelView
 		displaySettings.put( KEY_TRACKS_VISIBLE, true );
 		displaySettings.put( KEY_TRACK_DISPLAY_MODE, DEFAULT_TRACK_DISPLAY_MODE );
 		displaySettings.put( KEY_TRACK_DISPLAY_DEPTH, DEFAULT_TRACK_DISPLAY_DEPTH );
-		displaySettings.put( KEY_COLORMAP, DEFAULT_COLOR_MAP );
+		displaySettings.put( KEY_COLORMAP, TrackMateOptionUtils.getOptions().getPaintScale() );
 	}
 
 	/*

--- a/src/main/java/org/jfree/chart/renderer/InterpolatePaintScale.java
+++ b/src/main/java/org/jfree/chart/renderer/InterpolatePaintScale.java
@@ -25,7 +25,7 @@ public class InterpolatePaintScale implements PaintScale, Serializable
 	 */
 	
 	/**
-	 * A {@link InterpolatePaintScale} that map a typical "Jet" colormap going from
+	 * An {@link InterpolatePaintScale} that maps a typical "Jet" colormap going from
 	 * blue to red to the range [0, 1].
 	 */
 	public static final InterpolatePaintScale Jet;
@@ -40,6 +40,34 @@ public class InterpolatePaintScale implements PaintScale, Serializable
 		Jet.add(1.00, new Color(1.0f, 0.0f, 0.0f));
 	}
 	
+	/**
+	 * An {@link InterpolatePaintScale} that replicates the matplotlib "Viridis" colormap.
+	 */
+	public static final InterpolatePaintScale Viridis;
+	static {
+		Viridis = new InterpolatePaintScale(0, 1);
+		Viridis.add(0.00, new Color( 68,   1,  84));
+		Viridis.add(0.05, new Color( 71,  18, 101));
+		Viridis.add(0.10, new Color( 72,  35, 116));
+		Viridis.add(0.15, new Color( 69,  52, 127));
+		Viridis.add(0.20, new Color( 64,  67, 135));
+		Viridis.add(0.25, new Color( 58,  82, 139));
+		Viridis.add(0.30, new Color( 52,  94, 141));
+		Viridis.add(0.35, new Color( 46, 107, 142));
+		Viridis.add(0.40, new Color( 41, 120, 142));
+		Viridis.add(0.45, new Color( 36, 132, 141));
+		Viridis.add(0.50, new Color( 32, 144, 140));
+		Viridis.add(0.55, new Color( 30, 155, 137));
+		Viridis.add(0.60, new Color( 34, 167, 132));
+		Viridis.add(0.65, new Color( 47, 179, 123));
+		Viridis.add(0.70, new Color( 68, 190, 112));
+		Viridis.add(0.75, new Color( 94, 201,  97));
+		Viridis.add(0.80, new Color(121, 209,  81));
+		Viridis.add(0.85, new Color(154, 216,  60));
+		Viridis.add(0.90, new Color(189, 222,  38));
+		Viridis.add(0.95, new Color(223, 227,  24));
+		Viridis.add(1.00, new Color(253, 231,  36));
+	}
 	
 	/*
 	 * CONSTRUCTORS


### PR DESCRIPTION
I propose to add the _viridis_ color map from matplotlib. It is superior to the Jet color map because it is perceptually uniform, see [this post](https://bids.github.io/colormap/).
In this PR, I made viridis the new default. More changes are required to allow this as a user-configurable option.
