### PR TITLE
Allow spot detection on images with a discontinuous ShapeRoi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<url>http://imagej.net/User:Haesleinhuepf</url>
 			<properties><id>haesleinhuepf</id></properties>
 		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>http://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
 	</contributors>
 
 	<scm>

--- a/src/main/java/fiji/plugin/trackmate/Settings.java
+++ b/src/main/java/fiji/plugin/trackmate/Settings.java
@@ -39,6 +39,13 @@ public class Settings
 	 */
 	public Polygon polygon;
 
+	/**
+	 * The region of interest (ROI). This will be used to crop the image and to
+	 * discard found spots outside the ROI. If <code>null</code>, the whole
+	 * image is considered.
+	 */
+	public Roi roi;
+
 	// Crop cube
 	/**
 	 * The time-frame index, <b>0-based</b>, of the first time-point to process.
@@ -217,7 +224,7 @@ public class Settings
 		this.zend = imp.getNSlices() - 1;
 		this.tstart = 0;
 		this.tend = imp.getNFrames() - 1;
-		final Roi roi = imp.getRoi();
+		this.roi = imp.getRoi();
 		if ( roi == null )
 		{
 			this.xstart = 0;

--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -13,6 +13,7 @@ import fiji.plugin.trackmate.features.SpotFeatureCalculator;
 import fiji.plugin.trackmate.features.TrackFeatureCalculator;
 import fiji.plugin.trackmate.tracking.SpotTracker;
 import fiji.plugin.trackmate.util.TMUtils;
+import ij.gui.ShapeRoi;
 import net.imagej.ImgPlus;
 import net.imglib2.Interval;
 import net.imglib2.algorithm.Algorithm;
@@ -108,9 +109,18 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 		TMUtils.translateSpots( spotsThisFrame, settings.xstart * calibration[ 0 ], settings.ystart * calibration[ 1 ], settings.zstart * calibration[ 2 ] );
 		List< Spot > prunedSpots;
 		// Prune if outside of ROI
-		if ( null != settings.polygon )
+		if ( settings.roi instanceof ShapeRoi )
 		{
-			prunedSpots = new ArrayList< Spot >();
+			prunedSpots = new ArrayList<>();
+			for ( final Spot spot : spotsThisFrame )
+			{
+				if ( settings.roi.contains( (int) Math.round( spot.getFeature( Spot.POSITION_X ) / calibration[ 0 ] ), (int) Math.round( spot.getFeature( Spot.POSITION_Y ) / calibration[ 1 ] ) ) )
+					prunedSpots.add( spot );
+			}
+		}
+		else if ( null != settings.polygon )
+		{
+			prunedSpots = new ArrayList<>();
 			for ( final Spot spot : spotsThisFrame )
 			{
 				if ( settings.polygon.contains( spot.getFeature( Spot.POSITION_X ) / calibration[ 0 ], spot.getFeature( Spot.POSITION_Y ) / calibration[ 1 ] ) )
@@ -395,7 +405,16 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 								}
 
 								List< Spot > prunedSpots;
-								if ( null != settings.polygon )
+								if ( settings.roi instanceof ShapeRoi )
+								{
+									prunedSpots = new ArrayList<>();
+									for ( final Spot spot : spotsThisFrame )
+									{
+										if ( settings.roi.contains( (int) Math.round( spot.getFeature( Spot.POSITION_X ) / calibration[ 0 ] ), (int) Math.round( spot.getFeature( Spot.POSITION_Y ) / calibration[ 1 ] ) ) )
+											prunedSpots.add( spot );
+									}
+								}
+								else if ( null != settings.polygon )
 								{
 									prunedSpots = new ArrayList< Spot >();
 									for ( final Spot spot : spotsThisFrame )

--- a/src/main/java/fiji/plugin/trackmate/gui/panels/StartDialogPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/panels/StartDialogPanel.java
@@ -158,6 +158,7 @@ public class StartDialogPanel extends ActionListenablePanel
 		final Roi roi = imp.getRoi();
 		if ( null != roi )
 		{
+			settings.roi = roi;
 			settings.polygon = roi.getPolygon();
 		}
 		// File info


### PR DESCRIPTION
If the current ROI is an `ij.gui.ShapeRoi`, we use this to filter the spot detections in each frame. For other cases, we keep the `settings.polygon` for backward compatibility.

See [this discussion](http://forum.imagej.net/t/trackmate-dynamic-filtering-of-spots-after-detection-before-tracking/4246?u=imagejan) on the forum.