### PR TITLE
minor change: Disposible trackscheme for multiple single tiff analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@
 
 ## MacOSX
 .DS_Store
+
+## IntelliJ (IDEA) ##
+*.iml
+*.eml
+.idea/
+.idea/libraries/

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackScheme.java
@@ -1036,6 +1036,10 @@ public class TrackScheme extends AbstractTrackMateModelView
 		gui.setVisible( true );
 	}
 
+	public void dispose(){
+	   gui.dispose();
+   }
+
 	/*
 	 * INNER CLASSES
 	 */


### PR DESCRIPTION
Hello, thanks for this convenient tool for trakcing, i'm using it almost every day.
I have just noticed that when running trackmate headlessly, it is not possible to dispose the Trackscheme panel with command line. When i run hundreds of tracking of single tiff, my desktop can be freezed :(
So i just added a method to make it disposable (and updated gitignore for intellij).
Tell me what you think 