### PR TITLE
Specify range when capture TrackMate overlay.

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayAction.java
@@ -1,15 +1,5 @@
 package fiji.plugin.trackmate.action;
 
-import fiji.plugin.trackmate.TrackMate;
-import fiji.plugin.trackmate.gui.TrackMateGUIController;
-import fiji.plugin.trackmate.visualization.trackscheme.TrackSchemeFrame;
-import ij.IJ;
-import ij.ImagePlus;
-import ij.ImageStack;
-import ij.gui.ImageCanvas;
-import ij.gui.ImageWindow;
-import ij.process.ColorProcessor;
-
 import java.awt.AWTException;
 import java.awt.Image;
 import java.awt.Point;
@@ -20,14 +10,25 @@ import javax.swing.ImageIcon;
 
 import org.scijava.plugin.Plugin;
 
-public class CaptureOverlayAction extends AbstractTMAction {
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.gui.TrackMateGUIController;
+import fiji.plugin.trackmate.visualization.trackscheme.TrackSchemeFrame;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.gui.ImageCanvas;
+import ij.gui.ImageWindow;
+import ij.process.ColorProcessor;
 
+public class CaptureOverlayAction extends AbstractTMAction
+{
 
+	public static final ImageIcon ICON = new ImageIcon( TrackSchemeFrame.class.getResource( "resources/camera_go.png" ) );
 
-	public static final ImageIcon ICON = new ImageIcon(TrackSchemeFrame.class.getResource("resources/camera_go.png"));
 	public static final String NAME = "Capture overlay";
 
 	public static final String KEY = "CAPTURE_OVERLAY";
+
 	public static final String INFO_TEXT = "<html>" +
 			"If the current displayer is the HyperstackDisplayer, this action <br>" +
 			"will capture the TrackMate overlay with current display settings. <br>" +
@@ -36,15 +37,17 @@ public class CaptureOverlayAction extends AbstractTMAction {
 			"<p>" +
 			"It can take long since we pause between each frame to ensure the whole <br>" +
 			"overlay is redrawn. The current zoom is taken into account. <br>" +
-			"Also, make sure nothing is moved over the image while capturing. "+
+			"Also, make sure nothing is moved over the image while capturing. " +
 			"</html>";
 
 	@Override
-	public void execute(final TrackMate trackmate) {
-		logger.log("Capturing TrackMate overlay.\n");
-		logger.log("  Preparing and allocating memory...");
-		try {
-			final ImagePlus imp =  trackmate.getSettings().imp;
+	public void execute( final TrackMate trackmate )
+	{
+		logger.log( "Capturing TrackMate overlay.\n" );
+		logger.log( "  Preparing and allocating memory..." );
+		try
+		{
+			final ImagePlus imp = trackmate.getSettings().imp;
 			final ImageWindow win = imp.getWindow();
 			win.toFront();
 			final Point loc = win.getLocation();
@@ -52,30 +55,36 @@ public class CaptureOverlayAction extends AbstractTMAction {
 			final Rectangle bounds = ic.getBounds();
 			loc.x += bounds.x;
 			loc.y += bounds.y;
-			final Rectangle r = new Rectangle(loc.x, loc.y, bounds.width, bounds.height);
-			final ImageStack stack = new ImageStack(bounds.width, bounds.height);
+			final Rectangle r = new Rectangle( loc.x, loc.y, bounds.width, bounds.height );
+			final ImageStack stack = new ImageStack( bounds.width, bounds.height );
 			Robot robot;
-			try {
+			try
+			{
 				robot = new Robot();
-			} catch (final AWTException e) {
-				logger.error("Problem creating the image grabber:\n"+e.getLocalizedMessage());
+			}
+			catch ( final AWTException e )
+			{
+				logger.error( "Problem creating the image grabber:\n" + e.getLocalizedMessage() );
 				return;
 			}
-			logger.log(" done.\n");
+			logger.log( " done.\n" );
 
-			logger.log("  Performing capture...");
-			for (int i = 0; i < imp.getStackSize(); i++) {
-				logger.setProgress((float) i / imp.getStackSize());
-				imp.setPosition(i+1);
-				IJ.wait(200);
-				final Image image = robot.createScreenCapture(r);
-				final ColorProcessor cp = new ColorProcessor(image);
-				stack.addSlice(null, cp);
+			logger.log( "  Performing capture..." );
+			for ( int i = 0; i < imp.getStackSize(); i++ )
+			{
+				logger.setProgress( ( float ) i / imp.getStackSize() );
+				imp.setPosition( i + 1 );
+				IJ.wait( 200 );
+				final Image image = robot.createScreenCapture( r );
+				final ColorProcessor cp = new ColorProcessor( image );
+				stack.addSlice( null, cp );
 			}
-			new ImagePlus("TrackMate capture", stack).show();
-			logger.log(" done.\n");
-		} finally {
-			logger.setProgress(0);
+			new ImagePlus( "TrackMate capture", stack ).show();
+			logger.log( " done.\n" );
+		}
+		finally
+		{
+			logger.setProgress( 0 );
 		}
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayPanel.java
@@ -1,0 +1,106 @@
+package fiji.plugin.trackmate.action;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.text.NumberFormat;
+
+import javax.swing.JFormattedTextField;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+public class CaptureOverlayPanel extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private int firstFrame;
+
+	private int lastFrame;
+
+	public CaptureOverlayPanel( final int firstFrame, final int lastFrame )
+	{
+		this.firstFrame = firstFrame;
+		this.lastFrame = lastFrame;
+
+		final GridBagLayout gridBagLayout = new GridBagLayout();
+		gridBagLayout.columnWidths = new int[] { 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0 };
+		gridBagLayout.columnWeights = new double[] { 1.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 1.0, Double.MIN_VALUE };
+		setLayout( gridBagLayout );
+
+		final JLabel lblFirstFrame = new JLabel( "First frame:" );
+		final GridBagConstraints gbc_lblFirstFrame = new GridBagConstraints();
+		gbc_lblFirstFrame.anchor = GridBagConstraints.EAST;
+		gbc_lblFirstFrame.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblFirstFrame.gridx = 0;
+		gbc_lblFirstFrame.gridy = 0;
+		add( lblFirstFrame, gbc_lblFirstFrame );
+
+		final JFormattedTextField tftFirst = new JFormattedTextField( NumberFormat.getIntegerInstance() );
+		tftFirst.setValue( Integer.valueOf( firstFrame ) );
+		tftFirst.setColumns( 5 );
+		final GridBagConstraints gbc_tftFirst = new GridBagConstraints();
+		gbc_tftFirst.anchor = GridBagConstraints.NORTH;
+		gbc_tftFirst.insets = new Insets( 0, 0, 5, 0 );
+		gbc_tftFirst.fill = GridBagConstraints.HORIZONTAL;
+		gbc_tftFirst.gridx = 1;
+		gbc_tftFirst.gridy = 0;
+		add( tftFirst, gbc_tftFirst );
+
+		final JLabel lblLastFrame = new JLabel( "Last frame:" );
+		final GridBagConstraints gbc_lblLastFrame = new GridBagConstraints();
+		gbc_lblLastFrame.anchor = GridBagConstraints.EAST;
+		gbc_lblLastFrame.insets = new Insets( 0, 0, 5, 5 );
+		gbc_lblLastFrame.gridx = 0;
+		gbc_lblLastFrame.gridy = 1;
+		add( lblLastFrame, gbc_lblLastFrame );
+
+		final JFormattedTextField tftLast = new JFormattedTextField( NumberFormat.getIntegerInstance() );
+		tftLast.setValue( Integer.valueOf( lastFrame ) );
+		tftLast.setColumns( 5 );
+		final GridBagConstraints gbc_tftLast = new GridBagConstraints();
+		gbc_tftLast.insets = new Insets( 0, 0, 5, 0 );
+		gbc_tftLast.fill = GridBagConstraints.HORIZONTAL;
+		gbc_tftLast.gridx = 1;
+		gbc_tftLast.gridy = 1;
+		add( tftLast, gbc_tftLast );
+
+		final FocusListener fl = new FocusAdapter()
+		{
+			@Override
+			public void focusGained( final FocusEvent e )
+			{
+				SwingUtilities.invokeLater( new Runnable()
+				{
+					@Override
+					public void run()
+					{
+						( ( JFormattedTextField ) e.getSource() ).selectAll();
+					}
+				} );
+			}
+		};
+		tftFirst.addFocusListener( fl );
+		tftLast.addFocusListener( fl );
+
+		tftFirst.addPropertyChangeListener( "value", ( e ) -> this.firstFrame = ( ( Number ) tftFirst.getValue() ).intValue() );
+		tftLast.addPropertyChangeListener( "value", ( e ) -> this.lastFrame = ( ( Number ) tftLast.getValue() ).intValue() );
+	}
+
+	public int getFirstFrame()
+	{
+		return firstFrame;
+	}
+
+	public int getLastFrame()
+	{
+		return lastFrame;
+	}
+
+}


### PR DESCRIPTION
The capture overlay action nows only iterate over time, and capture the current channel and Z. 
It also prompts the user for the range they wish to capture.

![trackmateoverlayexportrange](https://user-images.githubusercontent.com/3583203/37337498-c1beeb74-26b4-11e8-9758-e0beb2e86674.png)
