### PR TITLE
 Make the capture-overlay action more usable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 ## MacOSX
 .DS_Store
+
+## SciJava release tools
+pom.xml.releaseBackup

--- a/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CaptureOverlayAction.java
@@ -1,5 +1,6 @@
 package fiji.plugin.trackmate.action;
 
+import java.awt.Component;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -10,6 +11,7 @@ import javax.swing.JOptionPane;
 import org.scijava.plugin.Plugin;
 
 import fiji.plugin.trackmate.LoadTrackMatePlugIn_;
+import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.gui.TrackMateGUIController;
 import fiji.plugin.trackmate.gui.TrackMateWizard;
@@ -42,15 +44,13 @@ public class CaptureOverlayAction extends AbstractTMAction
 			"Also, make sure nothing is moved over the image while capturing. " +
 			"</html>";
 
-	private final TrackMateWizard gui;
+	private final Component gui;
 
 	private static int firstFrame = -1;
 
 	private static int lastFrame = -1;
 
-	private ImagePlus capture;
-
-	public CaptureOverlayAction( final TrackMateWizard gui )
+	public CaptureOverlayAction( final Component gui )
 	{
 		this.gui = gui;
 	}
@@ -67,27 +67,85 @@ public class CaptureOverlayAction extends AbstractTMAction
 			lastFrame = imp.getNFrames();
 		lastFrame = Math.min( lastFrame, imp.getNFrames() );
 
-		final CaptureOverlayPanel panel = new CaptureOverlayPanel( firstFrame, lastFrame );
-		final int userInput = JOptionPane.showConfirmDialog( gui, panel, "Capture TrackMate overlay", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, TrackMateWizard.TRACKMATE_ICON );
-		if ( userInput != JOptionPane.OK_OPTION )
-			return;
+		if ( gui != null )
+		{
+			final CaptureOverlayPanel panel = new CaptureOverlayPanel( firstFrame, lastFrame );
+			final int userInput = JOptionPane.showConfirmDialog(
+					gui,
+					panel,
+					"Capture TrackMate overlay",
+					JOptionPane.OK_CANCEL_OPTION,
+					JOptionPane.QUESTION_MESSAGE,
+					TrackMateWizard.TRACKMATE_ICON );
 
-		final int first = panel.getFirstFrame();
-		final int last = panel.getLastFrame();
-		firstFrame = Math.min( last, first );
-		lastFrame = Math.max( last, first );
-		firstFrame = Math.max( 1, firstFrame );
-		lastFrame = Math.min( imp.getNFrames(), lastFrame );
+			if ( userInput != JOptionPane.OK_OPTION )
+				return;
+
+			final int first = panel.getFirstFrame();
+			final int last = panel.getLastFrame();
+			firstFrame = Math.min( last, first );
+			lastFrame = Math.max( last, first );
+			firstFrame = Math.max( 1, firstFrame );
+			lastFrame = Math.min( imp.getNFrames(), lastFrame );
+		}
+
+		final ImagePlus capture = capture( trackmate, firstFrame, lastFrame );
+		capture.show();
+	}
+
+	/**
+	 * Generates a new ImagePlus of type RGB, 2D over time, made by capturing
+	 * each time frame of the TrackMate display. The zoom level and overlay are
+	 * captured as is. If the ImagePlus used by TrackMate as multiple Z-slices,
+	 * or multiple channels, the current Z-slice and channel are captured as is.
+	 *
+	 * @param trackmate
+	 *            the TrackMate instance to use for capture.
+	 * @param first
+	 *            the first frame, inclusive, to capture.
+	 * @param last
+	 *            the last frame, inclusive, to capture.
+	 * @return a new ImagePlus.
+	 */
+	public static ImagePlus capture( final TrackMate trackmate, final int first, final int last )
+	{
+		final Logger logger = trackmate.getModel().getLogger();
+		final ImagePlus imp = trackmate.getSettings().imp;
+		return capture( imp, first, last, logger );
+	}
+
+	/**
+	 * Generates a new ImagePlus of type RGB, 2D over time, made by capturing
+	 * each time frame of the specified ImagePlus. The zoom level and overlay
+	 * are captured as is. If the specified ImagePlus as multiple Z-slices, or
+	 * multiple channels, the current Z-slice and channel are captured as is.
+	 *
+	 * @param imp
+	 *            the ImagePlus to capture.
+	 * @param first
+	 *            the first frame, inclusive, to capture.
+	 * @param last
+	 *            the last frame, inclusive, to capture.
+	 * @param log
+	 *            a {@link Logger} to report capture progress. Can be
+	 *            <code>null</code>.
+	 * @return a new ImagePlus.
+	 */
+	public static ImagePlus capture( final ImagePlus imp, final int first, final int last, final Logger log )
+	{
+		final Logger logger = ( null == log ) ? Logger.VOID_LOGGER : log;
+		final int firstFrame = Math.max( 1,
+				Math.min( last, first ) );
+		final int lastFrame = Math.min( imp.getNFrames(),
+				Math.max( last, first ) );
 
 		logger.log( "Capturing TrackMate overlay from frame " + firstFrame + " to " + lastFrame + ".\n" );
 		final Rectangle bounds = imp.getCanvas().getBounds();
 		final int width = bounds.width;
 		final int height = bounds.height;
-		final ImageStack stack = new ImageStack( width, height );
-		logger.log( " done.\n" );
-
 		final int nCaptures = lastFrame - firstFrame + 1;
-		logger.log( "Performing capture..." );
+		final ImageStack stack = new ImageStack( width, height );
+
 		final int channel = imp.getChannel();
 		final int slice = imp.getSlice();
 		imp.getCanvas().hideZoomIndicator( true );
@@ -102,12 +160,13 @@ public class CaptureOverlayAction extends AbstractTMAction
 			stack.addSlice( imp.getImageStack().getSliceLabel( index ), cp );
 		}
 		imp.getCanvas().hideZoomIndicator( false );
-		this.capture = new ImagePlus( "TrackMate capture of " + imp.getShortTitle(), stack );
+		final ImagePlus capture = new ImagePlus( "TrackMate capture of " + imp.getShortTitle(), stack );
 		transferCalibration( imp, capture );
-		capture.show();
 
 		logger.log( " done.\n" );
 		logger.setProgress( 0. );
+
+		return capture;
 	}
 
 	/**
@@ -120,7 +179,7 @@ public class CaptureOverlayAction extends AbstractTMAction
 	 * @param to
 	 *            the imp to copy to.
 	 */
-	private void transferCalibration( final ImagePlus from, final ImagePlus to )
+	private static final void transferCalibration( final ImagePlus from, final ImagePlus to )
 	{
 		final Calibration fc = from.getCalibration();
 		final Calibration tc = to.getCalibration();
@@ -133,18 +192,6 @@ public class CaptureOverlayAction extends AbstractTMAction
 		tc.pixelWidth = fc.pixelWidth / mag;
 		tc.pixelHeight = fc.pixelHeight / mag;
 		tc.pixelDepth = fc.pixelDepth;
-	}
-
-	/**
-	 * Returns a the {@link ImagePlus} resulting from the last
-	 * {@link #execute(TrackMate)} call.
-	 *
-	 * @return a RGB {@link ImagePlus}, or <code>null</code> if the
-	 *         {@link #execute(TrackMate)} has not been called yet.
-	 */
-	public ImagePlus getCapture()
-	{
-		return capture;
 	}
 
 	@Plugin( type = TrackMateActionFactory.class )
@@ -186,7 +233,7 @@ public class CaptureOverlayAction extends AbstractTMAction
 	public static void main( final String[] args )
 	{
 		ImageJ.main( args );
-		final File file = new File( "/Users/tinevez/Google Drive/Projects/Contacts/raw data/2015-09-17/Trackmate files/SiC + SAg2_1_20_BCells.xml" );
+		final File file = new File( "samples/FakeTracks.xml" );
 		final LoadTrackMatePlugIn_ loader = new LoadTrackMatePlugIn_();
 		loader.run( file.getAbsolutePath() );
 
@@ -204,6 +251,7 @@ public class CaptureOverlayAction extends AbstractTMAction
 		}
 
 		final TrackMate trackmate = loader.getController().getPlugin();
-		new CaptureOverlayAction( loader.getController().getGUI() ).execute( trackmate );
+		final ImagePlus capture = CaptureOverlayAction.capture( trackmate, 15, 25 );
+		capture.show();
 	}
 }


### PR DESCRIPTION
Especially in scripts.

You can now call a static method like this:

``` java
final TrackMate trackmate = ...
final ImagePlus capture = CaptureOverlayAction.capture( trackmate, 15, 25 );
capture.show();
```

Fixes #142 