### PR TITLE
Make the results tables interactive.

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/action/CopyOverlayAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/CopyOverlayAction.java
@@ -16,6 +16,20 @@ import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACKS_
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACK_COLORING;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACK_DISPLAY_DEPTH;
 import static fiji.plugin.trackmate.visualization.TrackMateModelView.KEY_TRACK_DISPLAY_MODE;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+
+import org.scijava.plugin.Plugin;
+
 import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.features.edges.EdgeVelocityAnalyzer;
@@ -39,19 +53,6 @@ import fiji.plugin.trackmate.visualization.threedviewer.SpotDisplayer3DFactory;
 import fiji.plugin.trackmate.visualization.trackscheme.SpotImageUpdater;
 import fiji.plugin.trackmate.visualization.trackscheme.TrackScheme;
 import ij.ImagePlus;
-
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JFrame;
-
-import org.scijava.plugin.Plugin;
 
 public class CopyOverlayAction extends AbstractTMAction
 {
@@ -274,7 +275,7 @@ public class CopyOverlayAction extends AbstractTMAction
 			{
 				try
 				{
-					final ExportStatsToIJAction action = new ExportStatsToIJAction();
+					final ExportStatsToIJAction action = new ExportStatsToIJAction( selectionModel );
 					action.execute( trackmate );
 				}
 				finally

--- a/src/main/java/fiji/plugin/trackmate/action/ExportAllSpotsStatsAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportAllSpotsStatsAction.java
@@ -29,6 +29,8 @@ public class ExportAllSpotsStatsAction extends AbstractTMAction
 			+ "regardless of whether they are in a track or not."
 			+ "</html>";
 
+	private ResultsTable spotTable;
+
 	@Override
 	public void execute( final TrackMate trackmate )
 	{
@@ -42,7 +44,7 @@ public class ExportAllSpotsStatsAction extends AbstractTMAction
 		final Collection< String > spotFeatures = trackmate.getModel().getFeatureModel().getSpotFeatures();
 
 		// Create table
-		final ResultsTable spotTable = new ResultsTable();
+		this.spotTable = new ResultsTable();
 
 		final Iterable< Spot > iterable = model.getSpots().iterable( true );
 		for ( final Spot spot : iterable )
@@ -82,6 +84,18 @@ public class ExportAllSpotsStatsAction extends AbstractTMAction
 
 		// Show tables
 		spotTable.show( "All Spots statistics" );
+	}
+
+	/**
+	 * Returns the results table containing the spot statistics, or
+	 * <code>null</code> if the {@link #execute(TrackMate)} method has not been
+	 * called.
+	 *
+	 * @return the results table containing the spot statistics.
+	 */
+	public ResultsTable getSpotTable()
+	{
+		return spotTable;
 	}
 
 	@Plugin( type = TrackMateActionFactory.class )

--- a/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
@@ -256,7 +256,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 					final Set< Spot > spots = new HashSet<>();
 					for ( int row = minLine; row <= maxLine; row++ )
 					{
-						final int spotID = Integer.parseInt( spotTable.getStringValue( ID_COLUMN, row ) );
+						final int spotID = Integer.parseInt( spotTableTextPanel.getResultsTable().getStringValue( ID_COLUMN, row ) );
 						final Spot spot = model.getSpots().search( spotID );
 						if ( null != spot )
 							spots.add( spot );
@@ -298,9 +298,9 @@ public class ExportStatsToIJAction extends AbstractTMAction
 						final Set< DefaultWeightedEdge > edges = new HashSet<>();
 						for ( int row = minLine; row <= maxLine; row++ )
 						{
-							final int sourceID = Integer.parseInt( edgeTable.getStringValue( sourceIDColumn, row ) );
+							final int sourceID = Integer.parseInt( edgeTableTextPanel.getResultsTable().getStringValue( sourceIDColumn, row ) );
 							final Spot source = model.getSpots().search( sourceID );
-							final int targetID = Integer.parseInt( edgeTable.getStringValue( targetIDColumn, row ) );
+							final int targetID = Integer.parseInt( edgeTableTextPanel.getResultsTable().getStringValue( targetIDColumn, row ) );
 							final Spot target = model.getSpots().search( targetID );
 							final DefaultWeightedEdge edge = model.getTrackModel().getEdge( source, target );
 							if ( null != edge )
@@ -336,7 +336,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 					final Set< Spot > spots = new HashSet<>();
 					for ( int row = minLine; row <= maxLine; row++ )
 					{
-						final int trackID = Integer.parseInt( trackTable.getStringValue( TRACK_ID_COLUMN, row ) );
+						final int trackID = Integer.parseInt( trackTableTextPanel.getResultsTable().getStringValue( TRACK_ID_COLUMN, row ) );
 						spots.addAll( model.getTrackModel().trackSpots( trackID ) );
 						edges.addAll( model.getTrackModel().trackEdges( trackID ) );
 					}

--- a/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
@@ -1,9 +1,12 @@
 package fiji.plugin.trackmate.action;
 
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -14,13 +17,18 @@ import org.scijava.plugin.Plugin;
 
 import fiji.plugin.trackmate.FeatureModel;
 import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.features.edges.EdgeTargetAnalyzer;
 import fiji.plugin.trackmate.features.edges.EdgeTimeLocationAnalyzer;
 import fiji.plugin.trackmate.gui.TrackMateGUIController;
 import fiji.plugin.trackmate.gui.TrackMateWizard;
 import fiji.plugin.trackmate.util.ModelTools;
+import ij.WindowManager;
 import ij.measure.ResultsTable;
+import ij.text.TextPanel;
+import ij.text.TextWindow;
 
 public class ExportStatsToIJAction extends AbstractTMAction
 {
@@ -31,13 +39,41 @@ public class ExportStatsToIJAction extends AbstractTMAction
 
 	public static final String KEY = "EXPORT_STATS_TO_IJ";
 
-	public static final String INFO_TEXT = "<html>" + "Compute and export all statistics to 3 ImageJ results table." + "Statistisc are separated in features computed for:" + "<ol>" + "	<li> spots in filtered tracks;" + "	<li> links between those spots;" + "	<li> filtered tracks." + "</ol>" + "For tracks and links, they are recalculated prior to exporting. Note " + "that spots and links that are not in a filtered tracks are not part" + "of this export." + "</html>";
+	public static final String INFO_TEXT = "<html>"
+			+ "Compute and export all statistics to 3 ImageJ results table. "
+			+ "Statistisc are separated in features computed for: "
+			+ "<ol> "
+			+ "	<li> spots in filtered tracks; "
+			+ "	<li> links between those spots; "
+			+ "	<li> filtered tracks. "
+			+ "</ol> "
+			+ "For tracks and links, they are recalculated prior to exporting. Note "
+			+ "that spots and links that are not in a filtered tracks are not part "
+			+ "of this export."
+			+ "</html>";
+
+	private static final String SPOT_TABLE_NAME = "Spots in tracks statistics";
+
+	private static final String EDGE_TABLE_NAME = "Links in tracks statistics";
+
+	private static final String TRACK_TABLE_NAME = "Track statistics";
+
+	private static final String ID_COLUMN = "ID";
+
+	private static final String TRACK_ID_COLUMN = "TRACK_ID";
 
 	private ResultsTable spotTable;
 
 	private ResultsTable edgeTable;
 
 	private ResultsTable trackTable;
+
+	private final SelectionModel selectionModel;
+
+	public ExportStatsToIJAction( final SelectionModel selectionModel )
+	{
+		this.selectionModel = selectionModel;
+	}
 
 	@Override
 	public void execute( final TrackMate trackmate )
@@ -67,7 +103,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 			{
 				spotTable.incrementCounter();
 				spotTable.addLabel( spot.getName() );
-				spotTable.addValue( "ID", "" + spot.ID() );
+				spotTable.addValue( ID_COLUMN, "" + spot.ID() );
 				spotTable.addValue( "TRACK_ID", "" + trackID.intValue() );
 				for ( final String feature : spotFeatures )
 				{
@@ -123,7 +159,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 			{
 				edgeTable.incrementCounter();
 				edgeTable.addLabel( edge.toString() );
-				edgeTable.addValue( "TRACK_ID", "" + trackID.intValue() );
+				edgeTable.addValue( TRACK_ID_COLUMN, "" + trackID.intValue() );
 				for ( final String feature : edgeFeatures )
 				{
 					final Object o = fm.getEdgeFeature( edge, feature );
@@ -189,9 +225,126 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		logger.log( " Done.\n" );
 
 		// Show tables
-		spotTable.show( "Spots in tracks statistics" );
-		edgeTable.show( "Links in tracks statistics" );
-		trackTable.show( "Track statistics" );
+		spotTable.show( SPOT_TABLE_NAME );
+		edgeTable.show( EDGE_TABLE_NAME );
+		trackTable.show( TRACK_TABLE_NAME );
+
+		// Hack to make the results tables in sync with selection model.
+		if ( null != selectionModel )
+		{
+
+			/*
+			 * Spot table listener.
+			 */
+
+			final TextWindow spotTableWindow = ( TextWindow ) WindowManager.getWindow( SPOT_TABLE_NAME );
+			final TextPanel spotTableTextPanel = spotTableWindow.getTextPanel();
+			spotTableTextPanel.addMouseListener( new MouseAdapter()
+			{
+
+				@Override
+				public void mouseReleased( final MouseEvent e )
+				{
+					final int selStart = spotTableTextPanel.getSelectionStart();
+					final int selEnd = spotTableTextPanel.getSelectionEnd();
+					if ( selStart < 0 || selEnd < 0 )
+						return;
+
+					final int minLine = Math.min( selStart, selEnd );
+					final int maxLine = Math.max( selStart, selEnd );
+					final Set< Spot > spots = new HashSet<>();
+					for ( int row = minLine; row <= maxLine; row++ )
+					{
+						final int spotID = Integer.parseInt( spotTable.getStringValue( ID_COLUMN, row ) );
+						final Spot spot = model.getSpots().search( spotID );
+						if ( null != spot )
+							spots.add( spot );
+					}
+					selectionModel.clearSelection();
+					selectionModel.addSpotToSelection( spots );
+				}
+			} );
+
+			/*
+			 * Edge table listener.
+			 */
+
+			/*
+			 * We can only retrieve edges if the table contains the source and
+			 * target ID columns.
+			 */
+
+			final int sourceIDColumn = edgeTable.getColumnIndex( EdgeTargetAnalyzer.SPOT_SOURCE_ID );
+			final int targetIDColumn = edgeTable.getColumnIndex( EdgeTargetAnalyzer.SPOT_TARGET_ID );
+			if ( sourceIDColumn != ResultsTable.COLUMN_NOT_FOUND && targetIDColumn != ResultsTable.COLUMN_NOT_FOUND )
+			{
+
+				final TextWindow edgeTableWindow = ( TextWindow ) WindowManager.getWindow( EDGE_TABLE_NAME );
+				final TextPanel edgeTableTextPanel = edgeTableWindow.getTextPanel();
+				edgeTableTextPanel.addMouseListener( new MouseAdapter()
+				{
+
+					@Override
+					public void mouseReleased( final MouseEvent e )
+					{
+						final int selStart = edgeTableTextPanel.getSelectionStart();
+						final int selEnd = edgeTableTextPanel.getSelectionEnd();
+						if ( selStart < 0 || selEnd < 0 )
+							return;
+
+						final int minLine = Math.min( selStart, selEnd );
+						final int maxLine = Math.max( selStart, selEnd );
+						final Set< DefaultWeightedEdge > edges = new HashSet<>();
+						for ( int row = minLine; row <= maxLine; row++ )
+						{
+							final int sourceID = Integer.parseInt( edgeTable.getStringValue( sourceIDColumn, row ) );
+							final Spot source = model.getSpots().search( sourceID );
+							final int targetID = Integer.parseInt( edgeTable.getStringValue( targetIDColumn, row ) );
+							final Spot target = model.getSpots().search( targetID );
+							final DefaultWeightedEdge edge = model.getTrackModel().getEdge( source, target );
+							if ( null != edge )
+								edges.add( edge );
+						}
+						selectionModel.clearSelection();
+						selectionModel.addEdgeToSelection( edges );
+					}
+				} );
+			}
+
+
+			/*
+			 * Track table listener.
+			 */
+
+			final TextWindow trackTableWindow = ( TextWindow ) WindowManager.getWindow( TRACK_TABLE_NAME );
+			final TextPanel trackTableTextPanel = trackTableWindow.getTextPanel();
+			trackTableTextPanel.addMouseListener( new MouseAdapter()
+			{
+
+				@Override
+				public void mouseReleased( final MouseEvent e )
+				{
+					final int selStart = trackTableTextPanel.getSelectionStart();
+					final int selEnd = trackTableTextPanel.getSelectionEnd();
+					if ( selStart < 0 || selEnd < 0 )
+						return;
+
+					final int minLine = Math.min( selStart, selEnd );
+					final int maxLine = Math.max( selStart, selEnd );
+					final Set< DefaultWeightedEdge > edges = new HashSet<>();
+					final Set< Spot > spots = new HashSet<>();
+					for ( int row = minLine; row <= maxLine; row++ )
+					{
+						final int trackID = Integer.parseInt( trackTable.getStringValue( TRACK_ID_COLUMN, row ) );
+						spots.addAll( model.getTrackModel().trackSpots( trackID ) );
+						edges.addAll( model.getTrackModel().trackEdges( trackID ) );
+					}
+					selectionModel.clearSelection();
+					selectionModel.addSpotToSelection( spots );
+					selectionModel.addEdgeToSelection( edges );
+				}
+			} );
+		}
 	}
 
 	/**
@@ -250,7 +403,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		@Override
 		public TrackMateAction create( final TrackMateGUIController controller )
 		{
-			return new ExportStatsToIJAction();
+			return new ExportStatsToIJAction( controller.getSelectionModel() );
 		}
 
 		@Override

--- a/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
@@ -33,6 +33,12 @@ public class ExportStatsToIJAction extends AbstractTMAction
 
 	public static final String INFO_TEXT = "<html>" + "Compute and export all statistics to 3 ImageJ results table." + "Statistisc are separated in features computed for:" + "<ol>" + "	<li> spots in filtered tracks;" + "	<li> links between those spots;" + "	<li> filtered tracks." + "</ol>" + "For tracks and links, they are recalculated prior to exporting. Note " + "that spots and links that are not in a filtered tracks are not part" + "of this export." + "</html>";
 
+	private ResultsTable spotTable;
+
+	private ResultsTable edgeTable;
+
+	private ResultsTable trackTable;
+
 	@Override
 	public void execute( final TrackMate trackmate )
 	{
@@ -47,8 +53,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		final Set< Integer > trackIDs = model.getTrackModel().trackIDs( true );
 		final Collection< String > spotFeatures = trackmate.getModel().getFeatureModel().getSpotFeatures();
 
-		// Create table
-		final ResultsTable spotTable = new ResultsTable();
+		this.spotTable = new ResultsTable();
 
 		// Parse spots to insert values as objects
 		for ( final Integer trackID : trackIDs )
@@ -92,8 +97,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		// Yield available edge feature
 		final Collection< String > edgeFeatures = fm.getEdgeFeatures();
 
-		// Create table
-		final ResultsTable edgeTable = new ResultsTable();
+		this.edgeTable = new ResultsTable();
 
 		// Sort by track
 		for ( final Integer trackID : trackIDs )
@@ -155,8 +159,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		// Yield available edge feature
 		final Collection< String > trackFeatures = fm.getTrackFeatures();
 
-		// Create table
-		final ResultsTable trackTable = new ResultsTable();
+		this.trackTable = new ResultsTable();
 
 		// Sort by track
 		for ( final Integer trackID : trackIDs )
@@ -189,6 +192,42 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		spotTable.show( "Spots in tracks statistics" );
 		edgeTable.show( "Links in tracks statistics" );
 		trackTable.show( "Track statistics" );
+	}
+
+	/**
+	 * Returns the results table containing the spot statistics, or
+	 * <code>null</code> if the {@link #execute(TrackMate)} method has not been
+	 * called.
+	 *
+	 * @return the results table containing the spot statistics.
+	 */
+	public ResultsTable getSpotTable()
+	{
+		return spotTable;
+	}
+
+	/**
+	 * Returns the results table containing the edge statistics, or
+	 * <code>null</code> if the {@link #execute(TrackMate)} method has not been
+	 * called.
+	 *
+	 * @return the results table containing the edge statistics.
+	 */
+	public ResultsTable getEdgeTable()
+	{
+		return edgeTable;
+	}
+
+	/**
+	 * Returns the results table containing the track statistics, or
+	 * <code>null</code> if the {@link #execute(TrackMate)} method has not been
+	 * called.
+	 *
+	 * @return the results table containing the track statistics.
+	 */
+	public ResultsTable getTrackTable()
+	{
+		return trackTable;
 	}
 
 	// Invisible because called on the view config panel.
@@ -248,5 +287,5 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		}
 
 	}
-	
+
 }

--- a/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportStatsToIJAction.java
@@ -202,6 +202,7 @@ public class ExportStatsToIJAction extends AbstractTMAction
 		{
 			trackTable.incrementCounter();
 			trackTable.addLabel( model.getTrackModel().name( trackID ) );
+			trackTable.addValue( TRACK_ID_COLUMN, "" + trackID.intValue() );
 			for ( final String feature : trackFeatures )
 			{
 				final Double val = fm.getTrackFeature( trackID, feature );

--- a/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
@@ -784,7 +784,7 @@ public class TrackMateGUIController implements ActionListener
 				return viewChoiceDescriptor;
 
 			return detectionDescriptor;
-			
+
 		}
 		else if ( currentDescriptor == detectionDescriptor )
 		{
@@ -810,7 +810,7 @@ public class TrackMateGUIController implements ActionListener
 		{
 			if ( null == trackmate.getSettings().trackerFactory || trackmate.getSettings().trackerFactory.getKey().equals( ManualTrackerFactory.TRACKER_KEY ) )
 				return trackFilterDescriptor;
-			
+
 			return trackerConfigurationDescriptor;
 
 		}
@@ -1275,9 +1275,9 @@ public class TrackMateGUIController implements ActionListener
 				{
 					AbstractTMAction action;
 					if ( showAllSpotStats )
-						action = new ExportAllSpotsStatsAction();
+						action = new ExportAllSpotsStatsAction( selectionModel );
 					else
-						action = new ExportStatsToIJAction();
+						action = new ExportStatsToIJAction( selectionModel );
 
 					action.execute( trackmate );
 

--- a/src/test/java/fiji/plugin/trackmate/interactivetests/ExportStats_TestDrive.java
+++ b/src/test/java/fiji/plugin/trackmate/interactivetests/ExportStats_TestDrive.java
@@ -1,15 +1,15 @@
 package fiji.plugin.trackmate.interactivetests;
 
+import java.io.File;
+
+import org.scijava.util.AppUtils;
+
 import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.action.ExportStatsToIJAction;
 import fiji.plugin.trackmate.io.TmXmlReader;
 import ij.ImageJ;
-
-import java.io.File;
-
-import org.scijava.util.AppUtils;
 
 public class ExportStats_TestDrive {
 
@@ -30,7 +30,7 @@ public class ExportStats_TestDrive {
 		final TrackMate trackmate = new TrackMate(model, null);
 
 		// Export
-		final ExportStatsToIJAction exporter = new ExportStatsToIJAction();
+		final ExportStatsToIJAction exporter = new ExportStatsToIJAction( null );
 		exporter.execute(trackmate);
 
 	}


### PR DESCRIPTION
Upon the selection of a line in any of the 4 tables generated by TrackMate last panel:
- all spots statistics table;
- spots in tracks statistics table;
- links statistics table;
- tracks statistics table,

the corresponding data item gets automatically selected and highlighted:

![Screen Shot 2019-12-18 at 12 01 27](https://user-images.githubusercontent.com/3583203/71080755-12a38380-218e-11ea-80d3-9e0b69703741.png)

Commissioned by Pr. Xin Liang,  East China University of Science and Technology.

The reverse direction is NOT implemented (selecting one data item does not highlight it in the table).