### PR TITLE
Add current TrackMate instance to ObjectService

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.scijava.Named;
 import org.scijava.util.VersionUtils;
 
 import fiji.plugin.trackmate.detection.ManualDetectorFactory;
@@ -38,7 +39,7 @@ import net.imglib2.multithreading.SimpleMultiThreading;
  * @author Jean-Yves Tinevez - Institut Pasteur - July 2010 - 2018
  */
 @SuppressWarnings( "deprecation" )
-public class TrackMate implements Benchmark, MultiThreaded, Algorithm
+public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named
 {
 
 	public static final String PLUGIN_NAME_STR = "TrackMate";
@@ -58,6 +59,8 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 
 	protected int numThreads = Runtime.getRuntime().availableProcessors();
 
+	private String name;
+
 	/*
 	 * CONSTRUCTORS
 	 */
@@ -71,6 +74,10 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 	{
 		this.model = model;
 		this.settings = settings;
+		name = PLUGIN_NAME_STR + "_v" + PLUGIN_NAME_VERSION;
+		if ( settings.imp != null )
+			name += "_(" + settings.imp.getTitle().replace( ' ', '_' ) + ")";
+		name += "_[" + Integer.toHexString( hashCode() ) + "]";
 	}
 
 	public TrackMate()
@@ -563,7 +570,7 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 	@Override
 	public String toString()
 	{
-		return PLUGIN_NAME_STR + "v" + PLUGIN_NAME_VERSION;
+		return name;
 	}
 
 	/*
@@ -641,5 +648,19 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm
 	public long getProcessingTime()
 	{
 		return processingTime;
+	}
+
+	// --- org.scijava.Named methods ---
+
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+
+	@Override
+	public void setName( final String name )
+	{
+		this.name = name;
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/TrackMateService.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMateService.java
@@ -1,0 +1,24 @@
+package fiji.plugin.trackmate;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.script.ScriptService;
+import org.scijava.service.AbstractService;
+import org.scijava.service.Service;
+
+import net.imagej.ImageJService;
+
+@Plugin( type = Service.class )
+public class TrackMateService extends AbstractService implements ImageJService
+{
+
+	@Parameter
+	private ScriptService scriptService;
+
+	@Override
+	public void initialize()
+	{
+		scriptService.addAlias( TrackMate.class );
+	}
+
+}

--- a/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/TrackMateGUIController.java
@@ -32,6 +32,8 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.scijava.object.ObjectService;
+
 import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.SelectionModel;
@@ -218,6 +220,13 @@ public class TrackMateGUIController implements ActionListener
 
 		this.gui = new TrackMateWizard( this );
 		this.logger = gui.getLogger();
+
+		/*
+		 * Add this TrackMate instance to the ObjectService
+		 */
+		ObjectService objectService = TMUtils.getContext().service( ObjectService.class );
+		if ( objectService != null )
+			objectService.addObject( trackmate );
 
 		// Feature updater
 		final ModelFeatureUpdater modelFeatureUpdater = new ModelFeatureUpdater( trackmate.getModel(), trackmate.getSettings() );

--- a/src/main/java/fiji/plugin/trackmate/gui/TrackMateWizard.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/TrackMateWizard.java
@@ -17,8 +17,12 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
+import org.scijava.object.ObjectService;
+
 import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.gui.descriptors.WizardPanelDescriptor;
+import fiji.plugin.trackmate.util.TMUtils;
 import fiji.plugin.trackmate.visualization.TrackMateModelView;
 
 /**
@@ -196,6 +200,16 @@ public class TrackMateWizard extends JFrame implements ActionListener
 		fireAction( event );
 	}
 
+	@Override
+	public void dispose()
+	{
+		final ObjectService objectService = TMUtils.getContext().service( ObjectService.class );
+		if ( objectService != null )
+			objectService.removeObject( controller.getPlugin() );
+
+		super.dispose();
+	}
+
 	/**
 	 * Sets the current panel to that identified by the WizardPanelDescriptor
 	 * passed in.
@@ -331,7 +345,7 @@ public class TrackMateWizard extends JFrame implements ActionListener
 		{
 			setDefaultCloseOperation( WindowConstants.DISPOSE_ON_CLOSE );
 			setIconImage( TRACKMATE_ICON.getImage() );
-			setTitle( fiji.plugin.trackmate.TrackMate.PLUGIN_NAME_STR + " v" + fiji.plugin.trackmate.TrackMate.PLUGIN_NAME_VERSION );
+			setTitle( TrackMate.PLUGIN_NAME_STR + "v" + TrackMate.PLUGIN_NAME_VERSION );
 			{
 				jPanelMain = new JPanel();
 				getContentPane().add( jPanelMain, BorderLayout.CENTER );

--- a/src/main/resources/script_templates/TrackMate/Get_TrackMate_Instance_and_Export_Graph.groovy
+++ b/src/main/resources/script_templates/TrackMate/Get_TrackMate_Instance_and_Export_Graph.groovy
@@ -1,0 +1,22 @@
+#@ TrackMate tm
+#@ File (style="save", label="Save graph as (.dot)") outputFile
+
+@Grab('org.jgrapht:jgrapht-io:1.3.0')
+import org.jgrapht.io.DOTExporter
+import org.jgrapht.io.ComponentNameProvider
+
+model = tm.getModel()
+
+trackGraph = model.getTrackModel().copy(
+	{ new StringBuffer() },
+	{ spot, sb -> sb.append( spot.toString() ) },
+	null
+)
+
+exporter = new DOTExporter()
+exporter.setVertexIDProvider(new ComponentNameProvider() {
+	String getName(vertex) {
+		return vertex.toString()
+	}
+})
+exporter.exportGraph(trackGraph, outputFile)


### PR DESCRIPTION
This allows scripts to interact with a currently running TrackMate instance by defining a `#@ TrackMate` parameter.