### PR TITLE
Update to jgraphx 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,8 @@
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 		<!-- NB: Use ImgLib2 style code formatting (https://github.com/scijava/scijava-coding-style) -->
 		<scijava.coding-style>imglib2</scijava.coding-style>
+
+		<jgraphx.version>4.1.0</jgraphx.version>
 	</properties>
 
 	<repositories>
@@ -244,8 +246,9 @@
 			<artifactId>jfreechart</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.tinyjee.jgraphx</groupId>
+			<groupId>com.github.vlsi.mxgraph</groupId>
 			<artifactId>jgraphx</artifactId>
+			<version>${jgraphx.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/mxScaledLabelShape.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/mxScaledLabelShape.java
@@ -53,7 +53,7 @@ public class mxScaledLabelShape extends mxRectangleShape
 	private final Rectangle getImageBounds( final mxCellState state )
 	{
 		final Rectangle cellR = state.getRectangle();
-		final int arc = getArcSize( cellR.width, cellR.height ) / 2;
+		final int arc = getArcSize( state, cellR.width, cellR.height ) / 2;
 		final int minSize = Math.min( cellR.width - arc * 2, cellR.height - 4 );
 		final Rectangle imageBounds = new Rectangle( cellR.x + arc, cellR.y + 2, minSize, minSize );
 		return imageBounds;


### PR DESCRIPTION
And use the groupId sanctioned by the jgraphx developers. This avoids duplicate class conflicts with org.jgrapht:jgrapht-ext, which also depends on jgraphx.