### PR TITLE
Fix setting min & max for PerTrackFeatureColorGenerator.

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/PerTrackFeatureColorGenerator.java
@@ -197,8 +197,10 @@ public class PerTrackFeatureColorGenerator implements TrackColorGenerator, Model
 	@Override
 	public void setMinMax( final double min, final double max )
 	{
+		setAutoMinMaxMode( false );
 		this.min = min;
 		this.max = max;
+		refreshColorMap();
 	}
 
 	@Override


### PR DESCRIPTION
It was ignored before.
Noticed by @flowman