### PR TITLE
resolves #187 LogPanel Logger overrides toString() to return entire log

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/gui/components/LogPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/LogPanel.java
@@ -140,6 +140,12 @@ public class LogPanel extends JPanel
 					}
 				} );
 			}
+			
+			@Override
+			public String toString()
+			{
+				return getTextContent();
+			}
 		};
 	}
 


### PR DESCRIPTION
I was hoping to get access to the entire trackmate log within an Action. In trackmate v7 this isn't possible currently. I was thinking maybe we could just return the entire log when calling toString on the logger. This pattern would seem to follow the situation for the StringBuilderLogger. Just an idea. Feel free to reject if you don't like it.