### PR TITLE
SpotContrastAndSNRAnalyzerFactory: adjust javadoc

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/features/spot/SpotContrastAndSNRAnalyzerFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/features/spot/SpotContrastAndSNRAnalyzerFactory.java
@@ -43,7 +43,7 @@ import net.imglib2.type.numeric.RealType;
 /**
  * A factory for {@link SpotContrastAndSNRAnalyzer}s. Because the analyzers of
  * this factory depends on some features defined in
- * {@link SpotIntensityMultiCAnalyzer}s, we use a higher priority, so that
+ * {@link SpotIntensityMultiCAnalyzer}s, we use a lower priority, so that
  * computation are done after the aforementioned analyzer are done.
  *
  * @author Jean- Yves Tinevez


### PR DESCRIPTION
The priority of this factory is actually _lower_ than that of `SpotIntensityMultiCAnalyzerFactory`, so let's fix the explanation in the javadoc to reflect this.