### PR TITLE
A new spot detector based on the determinant of Hessian (DoH).

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/Settings.java
+++ b/src/main/java/fiji/plugin/trackmate/Settings.java
@@ -21,7 +21,6 @@
  */
 package fiji.plugin.trackmate;
 
-import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +82,7 @@ public class Settings
 	 * discard found spots outside the ROI. If <code>null</code>, the whole
 	 * image is considered.
 	 */
-	public Roi roi;
+	private Roi roi;
 
 	// Crop cube
 	/**
@@ -95,26 +94,6 @@ public class Settings
 	 * The time-frame index, <b>0-based</b>, of the last time-point to process.
 	 */
 	public int tend;
-
-	/**
-	 * The lowest pixel X position, <b>0-based</b>, of the volume to process.
-	 */
-	public int xstart;
-
-	/**
-	 * The highest pixel X position, <b>0-based</b>, of the volume to process.
-	 */
-	public int xend;
-
-	/**
-	 * The lowest pixel Y position, <b>0-based</b>, of the volume to process.
-	 */
-	public int ystart;
-
-	/**
-	 * The lowest pixel Y position, <b>0-based</b>, of the volume to process.
-	 */
-	public int yend;
 
 	/**
 	 * The lowest pixel Z position, <b>0-based</b>, of the volume to process.
@@ -252,23 +231,38 @@ public class Settings
 		this.zend = imp.getNSlices() - 1;
 		this.tstart = 0;
 		this.tend = imp.getNFrames() - 1;
-		this.roi = imp.getRoi();
-		if ( roi == null )
-		{
-			this.xstart = 0;
-			this.xend = width - 1;
-			this.ystart = 0;
-			this.yend = height - 1;
-		}
-		else
-		{
-			final Rectangle boundingRect = roi.getBounds();
-			this.xstart = boundingRect.x;
-			this.xend = boundingRect.width + boundingRect.x;
-			this.ystart = boundingRect.y;
-			this.yend = boundingRect.height + boundingRect.y;
-		}
+		setRoi( imp.getRoi() );
 		// The rest is left to the user
+	}
+
+	public Roi getRoi()
+	{
+		return roi;
+	}
+
+	public void setRoi( final Roi roi )
+	{
+		this.roi = roi;
+	}
+
+	public int getXstart()
+	{
+		return roi == null ? 0 : roi.getBounds().x;
+	}
+
+	public int getXend()
+	{
+		return roi == null ? width - 1 : roi.getBounds().x + roi.getBounds().width;
+	}
+
+	public int getYstart()
+	{
+		return roi == null ? 0 : roi.getBounds().y;
+	}
+
+	public int getYend()
+	{
+		return roi == null ? height - 1 : roi.getBounds().y + roi.getBounds().height;
 	}
 
 	/**
@@ -346,8 +340,8 @@ public class Settings
 		}
 
 		str.append( "Geometry:\n" );
-		str.append( String.format( "  X = %4d - %4d, dx = %g\n", xstart, xend, dx ) );
-		str.append( String.format( "  Y = %4d - %4d, dy = %g\n", ystart, yend, dy ) );
+		str.append( String.format( "  X = %4d - %4d, dx = %g\n", getXstart(), getXend(), dx ) );
+		str.append( String.format( "  Y = %4d - %4d, dy = %g\n", getYstart(), getYend(), dy ) );
 		str.append( String.format( "  Z = %4d - %4d, dz = %g\n", zstart, zend, dz ) );
 		str.append( String.format( "  T = %4d - %4d, dt = %g\n", tstart, tend, dt ) );
 

--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -48,6 +48,7 @@ import fiji.plugin.trackmate.features.SpotFeatureCalculator;
 import fiji.plugin.trackmate.features.TrackFeatureCalculator;
 import fiji.plugin.trackmate.tracking.SpotTracker;
 import fiji.plugin.trackmate.util.TMUtils;
+import ij.gui.Roi;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imglib2.Interval;
@@ -407,7 +408,8 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 			 * Filter out spots not in the ROI.
 			 */
 			final SpotCollection spots;
-			if ( settings.roi != null )
+			final Roi roi = settings.getRoi();
+			if ( roi != null )
 			{
 				spots = new SpotCollection();
 				spots.setNumThreads( numThreads );
@@ -420,7 +422,7 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 
 					for ( final Spot spot : spotsIt )
 					{
-						if ( settings.roi.contains(
+						if ( roi.contains(
 								( int ) Math.round( spot.getFeature( Spot.POSITION_X ) / calibration[ 0 ] ),
 								( int ) Math.round( spot.getFeature( Spot.POSITION_Y ) / calibration[ 1 ] ) ) )
 						{
@@ -534,12 +536,13 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 						}
 
 						List< Spot > prunedSpots;
-						if ( settings.roi != null )
+						final Roi roi = settings.getRoi();
+						if ( roi != null )
 						{
 							prunedSpots = new ArrayList<>();
 							for ( final Spot spot : spotsThisFrame )
 							{
-								if ( settings.roi.contains(
+								if ( roi.contains(
 										( int ) Math.round( spot.getFeature( Spot.POSITION_X ) / calibration[ 0 ] ),
 										( int ) Math.round( spot.getFeature( Spot.POSITION_Y ) / calibration[ 1 ] ) ) )
 									prunedSpots.add( spot );

--- a/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
@@ -509,4 +509,32 @@ public class DetectionUtils
 			singleChannel = ImgPlusViews.hyperSlice( singleTimePoint, singleTimePoint.dimensionIndex( Axes.CHANNEL ), channel );
 		return singleChannel;
 	}
+
+	/**
+	 * Normalize the pixel value of an image between 0 and 1.
+	 * 
+	 * @param <T>
+	 *            the type of pixels in the image. Must extend {@link RealType}.
+	 * @param input
+	 *            the input image (iterable).
+	 */
+	public static final < T extends RealType< T > > void normalize( final Iterable< T > input )
+	{
+		// Min & Max.
+		double max = Double.NEGATIVE_INFINITY;
+		double min = Double.POSITIVE_INFINITY;
+		for ( final T d : input )
+		{
+			final double val = d.getRealDouble();
+			if ( val > max )
+				max = val;
+			if ( val < min )
+				min = val;
+		}
+		for ( final T d : input )
+		{
+			final double val = d.getRealDouble();
+			d.setReal( ( val - min ) / ( max - min ) );
+		}
+	}
 }

--- a/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
@@ -120,7 +120,7 @@ public class DetectionUtils
 					final Settings lSettings = new Settings( settings.imp );
 					lSettings.tstart = frame;
 					lSettings.tend = frame;
-					lSettings.roi = settings.roi;
+					settings.setRoi( settings.imp.getRoi() );
 
 					lSettings.detectorFactory = detectorFactory;
 					lSettings.detectorSettings = detectorSettings;

--- a/src/main/java/fiji/plugin/trackmate/detection/DetectorKeys.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/DetectorKeys.java
@@ -69,6 +69,15 @@ public class DetectorKeys
 	public static final double DEFAULT_RADIUS = 5d;
 
 	/**
+	 * The key for the parameter that sets the target radius in the Z direction
+	 * for the detector. Expected values are {@link Double}s.
+	 */
+	public static final String KEY_RADIUS_Z = "RADIUS_Z";
+
+	/** A default value for the {@link #KEY_RADIUS_Z} parameter. */
+	public static final double DEFAULT_RADIUS_Z = 8.;
+
+	/**
 	 * The key identifying the parameter that sets the threshold for the LoG
 	 * detector. Spot found with a filtered value lowered than this threshold
 	 * will not be retained. Expected values are {@link Double}s.
@@ -111,6 +120,15 @@ public class DetectorKeys
 
 	/** A default value for the {@link #KEY_DO_MEDIAN_FILTERING} parameter. */
 	public static final boolean DEFAULT_DO_MEDIAN_FILTERING = false;
+
+	/**
+	 * The key for the parameter that states whether the quality values are
+	 * normalized from 0 to 1.
+	 */
+	public static final String KEY_NORMALIZE = "NORMALIZE";
+
+	/** A default value for the {@link #KEY_NORMALIZE} parameter. */
+	public static final boolean DEFAULT_NORMALIZE = false;
 
 	/**
 	 * The key identifying the parameter setting whether we use sub-pixel

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
@@ -67,7 +67,7 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 
 	private long processingTime;
 
-	private int numThreads;
+	private int nTasks;
 
 	private final boolean normalize;
 
@@ -207,7 +207,7 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 			final IntervalView< FloatType > to = Views.translate( det, minopposite );
 
 			// Find spots.
-			return DetectionUtils.findLocalMaxima( to, threshold, calibration, radiusXY, doSubPixelLocalization, numThreads );
+			return DetectionUtils.findLocalMaxima( to, threshold, calibration, radiusXY, doSubPixelLocalization, nTasks );
 		}
 		catch ( final IncompatibleTypeException | InterruptedException | ExecutionException e )
 		{
@@ -251,7 +251,7 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 		// Hessian calculation.
 		final IntervalView< T > input = Views.zeroMin( Views.interval( img, crop ) );
 		HessianMatrix.calculateMatrix( input, gaussian,
-				gradient, hessian, new OutOfBoundsBorderFactory<>(), numThreads, es,
+				gradient, hessian, new OutOfBoundsBorderFactory<>(), nTasks, es,
 				sigmas );
 
 		// Normalize for pixel size.
@@ -292,7 +292,7 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 		final CompositeIntervalView< R, RealComposite< R > > composite = Views.collapseReal( H );
 		final Img< R > det = factory.create( crop );
 
-		final TaskExecutor taskExecutor = TaskExecutors.forExecutorServiceAndNumTasks( es, numThreads );
+		final TaskExecutor taskExecutor = TaskExecutors.forExecutorServiceAndNumTasks( es, nTasks );
 		LoopBuilder.setImages( composite, det ).multiThreaded( taskExecutor ).forEachPixel(
 				( c, d ) -> d.setReal( detcalc.applyAsDouble( c ) ) );
 
@@ -320,18 +320,18 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 	@Override
 	public void setNumThreads()
 	{
-		this.numThreads = Runtime.getRuntime().availableProcessors() / 2;
+		this.nTasks = Runtime.getRuntime().availableProcessors() / 2;
 	}
 
 	@Override
-	public void setNumThreads( final int numThreads )
+	public void setNumThreads( final int nTasks )
 	{
-		this.numThreads = numThreads;
+		this.nTasks = nTasks;
 	}
 
 	@Override
 	public int getNumThreads()
 	{
-		return numThreads;
+		return nTasks;
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
@@ -163,6 +163,8 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 				}
 				final FinalInterval intervalroi = FinalInterval.wrap( min, max );
 				final FinalInterval intersect = Intervals.intersect( interval, intervalroi );
+				if ( Intervals.isEmpty( intersect ) )
+					continue;
 
 				// Process interval.
 				final List< Spot > spotsThisRoi = processInterval( intersect );

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
@@ -1,0 +1,270 @@
+package fiji.plugin.trackmate.detection;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.ToDoubleFunction;
+
+import fiji.plugin.trackmate.Spot;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.algorithm.MultiThreaded;
+import net.imglib2.algorithm.gradient.HessianMatrix;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
+import net.imglib2.parallel.TaskExecutor;
+import net.imglib2.parallel.TaskExecutors;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.RealComposite;
+
+public class HessianDetector< T extends RealType< T > & NativeType< T > > implements SpotDetector< T >, MultiThreaded
+{
+
+	/*
+	 * FIELDS
+	 */
+
+	private final static String BASE_ERROR_MESSAGE = "HessianDetector: ";
+
+	private final RandomAccessible< T > img;
+
+	private final Interval interval;
+
+	private final double[] calibration;
+
+	private final double radiusXY;
+
+	private final double radiusZ;
+
+	private final double threshold;
+
+	private final boolean doSubPixelLocalization;
+
+	private String errorMessage;
+
+	private List< Spot > spots;
+
+	private long processingTime;
+
+	private int numThreads;
+
+	private final boolean normalize;
+
+	/*
+	 * CONSTRUCTOR
+	 */
+
+	public HessianDetector(
+			final RandomAccessible< T > img,
+			final Interval interval,
+			final double[] calibration,
+			final double radiusXY,
+			final double radiusZ,
+			final double threshold,
+			final boolean normalize,
+			final boolean doSubPixelLocalization )
+	{
+		this.img = img;
+		this.interval = interval;
+		this.calibration = calibration;
+		this.radiusXY = radiusXY;
+		this.radiusZ = radiusZ;
+		this.threshold = threshold;
+		this.normalize = normalize;
+		this.doSubPixelLocalization = doSubPixelLocalization;
+		setNumThreads();
+	}
+
+	/*
+	 * METHODS
+	 */
+
+	@Override
+	public boolean checkInput()
+	{
+		if ( null == img )
+		{
+			errorMessage = BASE_ERROR_MESSAGE + "Image is null.";
+			return false;
+		}
+		if ( img.numDimensions() > 3 || img.numDimensions() < 2 )
+		{
+			errorMessage = BASE_ERROR_MESSAGE + "Image must be 2D or 3D, got " + img.numDimensions() + "D.";
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean process()
+	{
+		spots = null;
+		errorMessage = null;
+
+		final long start = System.currentTimeMillis();
+		try
+		{
+			final Img< DoubleType > det = computeHessianDeterminant();
+			if ( normalize )
+			{
+				// Min & Max.
+				double max = Double.NEGATIVE_INFINITY;
+				double min = Double.POSITIVE_INFINITY;
+				for ( final DoubleType d : det )
+				{
+					final double val = d.get();
+					if ( val > max )
+						max = val;
+					if ( val < min )
+						min = val;
+				}
+				for ( final DoubleType d : det )
+				{
+					final double val = d.get();
+					d.set( ( val - min ) / ( max - min ) );
+				}
+			}
+			spots = DetectionUtils.findLocalMaxima( det, threshold, calibration, radiusXY, doSubPixelLocalization, numThreads );
+		}
+		catch ( final IncompatibleTypeException | InterruptedException | ExecutionException e )
+		{
+			errorMessage = BASE_ERROR_MESSAGE + e.getMessage();
+			e.printStackTrace();
+			return false;
+		}
+
+		final long end = System.currentTimeMillis();
+		this.processingTime = end - start;
+		return true;
+	}
+
+	private final Img< DoubleType > computeHessianDeterminant() throws IncompatibleTypeException, InterruptedException, ExecutionException
+	{
+		final int n = img.numDimensions();
+
+		// Sigmas in pixel units.
+		final double[] radius = new double[] { radiusXY, radiusXY, radiusZ };
+		final double[] sigmas = new double[ n ];
+		for ( int d = 0; d < n; d++ )
+		{
+			final double cal = d < calibration.length ? calibration[ d ] : 1;
+			sigmas[ d ] = radius[ d ] / cal / Math.sqrt( n );
+		}
+
+		// Get a suitable image factory.
+		final long[] gradientDims = new long[ n + 1 ];
+		final long[] hessianDims = new long[ n + 1 ];
+		for ( int d = 0; d < n; d++ )
+		{
+			hessianDims[ d ] = interval.dimension( d );
+			gradientDims[ d ] = interval.dimension( d );
+		}
+		hessianDims[ n ] = n * ( n + 1 ) / 2;
+		gradientDims[ n ] = n;
+		final Dimensions hessianDimensions = FinalDimensions.wrap( hessianDims );
+		final FinalDimensions gradientDimensions = FinalDimensions.wrap( gradientDims );
+		final ImgFactory< DoubleType > factory = Util.getArrayOrCellImgFactory( hessianDimensions, new DoubleType() );
+		final Img< DoubleType > hessian = factory.create( hessianDimensions );
+		final Img< DoubleType > gradient = factory.create( gradientDimensions );
+		final Img< DoubleType > gaussian = factory.create( interval );
+
+		// Handle multithreading.
+		final ExecutorService es = Executors.newFixedThreadPool( numThreads );
+		// Hessian calculation.
+		HessianMatrix.calculateMatrix( img, gaussian,
+				gradient, hessian, new OutOfBoundsBorderFactory<>(), numThreads, es,
+				sigmas );
+
+		// Normalize for pixel size.
+		final IntervalView< DoubleType > H = HessianMatrix.scaleHessianMatrix( hessian, sigmas );
+
+		// Compute determinant.
+		final ToDoubleFunction< RealComposite< DoubleType > > detcalc;
+		if ( n == 2 )
+		{
+			detcalc = ( c ) -> {
+				final double a00 = c.get( 0 ).get();
+				final double a01 = c.get( 1 ).get();
+				final double a11 = c.get( 2 ).get();
+				final double det = a00 * a11 - a01 * a01;
+				return det;
+			};
+		}
+		else
+		{
+			detcalc = ( c ) -> {
+				final double a00 = c.get( 0 ).get();
+				final double a01 = c.get( 1 ).get();
+				final double a02 = c.get( 2 ).get();
+				final double a11 = c.get( 3 ).get();
+				final double a12 = c.get( 4 ).get();
+				final double a22 = c.get( 5 ).get();
+
+				final double x = a11 * a22 - a12 * a12;
+				final double y = a01 * a22 - a02 * a12;
+				final double z = a01 * a12 - a02 * a11;
+
+				final double det = a00 * x - a01 * y + a02 * z;
+				return -det;
+				// Change sign so that bright detections have positive values.
+			};
+		}
+
+		final CompositeIntervalView< DoubleType, RealComposite< DoubleType > > composite = Views.collapseReal( H );
+		final Img< DoubleType > det = factory.create( interval );
+
+		final TaskExecutor taskExecutor = TaskExecutors.forExecutorServiceAndNumTasks( es, numThreads );
+		LoopBuilder.setImages( composite, det ).multiThreaded( taskExecutor ).forEachPixel(
+				( c, d ) -> d.set( detcalc.applyAsDouble( c ) ) );
+
+		return det;
+	}
+
+	@Override
+	public List< Spot > getResult()
+	{
+		return spots;
+	}
+
+	@Override
+	public String getErrorMessage()
+	{
+		return errorMessage;
+	}
+
+	@Override
+	public long getProcessingTime()
+	{
+		return processingTime;
+	}
+
+	@Override
+	public void setNumThreads()
+	{
+		this.numThreads = Runtime.getRuntime().availableProcessors() / 2;
+	}
+
+	@Override
+	public void setNumThreads( final int numThreads )
+	{
+		this.numThreads = numThreads;
+	}
+
+	@Override
+	public int getNumThreads()
+	{
+		return numThreads;
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
@@ -117,25 +117,10 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 		try
 		{
 			final Img< DoubleType > det = computeHessianDeterminant();
+
 			if ( normalize )
-			{
-				// Min & Max.
-				double max = Double.NEGATIVE_INFINITY;
-				double min = Double.POSITIVE_INFINITY;
-				for ( final DoubleType d : det )
-				{
-					final double val = d.get();
-					if ( val > max )
-						max = val;
-					if ( val < min )
-						min = val;
-				}
-				for ( final DoubleType d : det )
-				{
-					final double val = d.get();
-					d.set( ( val - min ) / ( max - min ) );
-				}
-			}
+				DetectionUtils.normalize( det );
+
 			spots = DetectionUtils.findLocalMaxima( det, threshold, calibration, radiusXY, doSubPixelLocalization, numThreads );
 		}
 		catch ( final IncompatibleTypeException | InterruptedException | ExecutionException e )

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetectorFactory.java
@@ -1,0 +1,206 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2022 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package fiji.plugin.trackmate.detection;
+
+import static fiji.plugin.trackmate.detection.DetectorKeys.DEFAULT_NORMALIZE;
+import static fiji.plugin.trackmate.detection.DetectorKeys.DEFAULT_RADIUS_Z;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_DO_MEDIAN_FILTERING;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_DO_SUBPIXEL_LOCALIZATION;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_NORMALIZE;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_RADIUS;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_RADIUS_Z;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_TARGET_CHANNEL;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_THRESHOLD;
+import static fiji.plugin.trackmate.io.IOUtils.readBooleanAttribute;
+import static fiji.plugin.trackmate.io.IOUtils.readDoubleAttribute;
+import static fiji.plugin.trackmate.io.IOUtils.readIntegerAttribute;
+import static fiji.plugin.trackmate.io.IOUtils.writeAttribute;
+import static fiji.plugin.trackmate.io.IOUtils.writeDoSubPixel;
+import static fiji.plugin.trackmate.io.IOUtils.writeRadius;
+import static fiji.plugin.trackmate.io.IOUtils.writeTargetChannel;
+import static fiji.plugin.trackmate.io.IOUtils.writeThreshold;
+import static fiji.plugin.trackmate.util.TMUtils.checkMapKeys;
+import static fiji.plugin.trackmate.util.TMUtils.checkParameter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jdom2.Element;
+import org.scijava.plugin.Plugin;
+
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Settings;
+import fiji.plugin.trackmate.gui.components.ConfigurationPanel;
+import fiji.plugin.trackmate.gui.components.detector.HessianDetectorConfigurationPanel;
+import fiji.plugin.trackmate.util.TMUtils;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+@Plugin( type = SpotDetectorFactory.class )
+public class HessianDetectorFactory< T extends RealType< T > & NativeType< T > > extends LogDetectorFactory< T >
+{
+
+	public static final String DETECTOR_KEY = "HESSIAN_DETECTOR";
+
+	public static final String NAME = "Hessian detector";
+
+	public static final String INFO_TEXT = "<html>"
+			+ "This detector is based on computing the determinant of the <br>"
+			+ "Hessian matrix of the image to detector bright blobs.  "
+			+ "<p>"
+			+ "It can be configured with a different spots size in XY and Z. <br>"
+			+ "It can also return a normalized quality value, scaled from 0 <br>"
+			+ "to 1 for the spots of each time-point."
+			+ "<p>"
+			+ "As discussed in Mikolajczyk et al.(2005), this detector has <br>"
+			+ "a better edge response elimination than the LoG detector and is <br>"
+			+ "suitable for detect spots in images with many strong edges."
+			+ "</html>";
+
+	@Override
+	public SpotDetector< T > getDetector( final Interval interval, final int frame )
+	{
+		final double radiusXY = ( Double ) settings.get( KEY_RADIUS );
+		final double radiusZ = ( Double ) settings.get( KEY_RADIUS_Z );
+		final double thresholdQuality = ( Double ) settings.get( KEY_THRESHOLD );
+		final boolean doSubpixel = ( Boolean ) settings.get( KEY_DO_SUBPIXEL_LOCALIZATION );
+		final boolean normalize = ( Boolean ) settings.get( KEY_NORMALIZE );
+
+		final double[] calibration = TMUtils.getSpatialCalibration( img );
+		final RandomAccessibleInterval< T > imFrame = prepareFrameImg( frame );
+
+		final HessianDetector< T > detector = new HessianDetector<>(
+				Views.extendMirrorDouble( imFrame ),
+				interval,
+				calibration,
+				radiusXY,
+				radiusZ,
+				thresholdQuality,
+				normalize,
+				doSubpixel );
+		detector.setNumThreads( 1 );
+		return detector;
+	}
+
+	@Override
+	public String getKey()
+	{
+		return DETECTOR_KEY;
+	}
+
+	@Override
+	public boolean checkSettings( final Map< String, Object > lSettings )
+	{
+		boolean ok = true;
+		final StringBuilder errorHolder = new StringBuilder();
+		ok = ok & checkParameter( lSettings, KEY_TARGET_CHANNEL, Integer.class, errorHolder );
+		ok = ok & checkParameter( lSettings, KEY_RADIUS, Double.class, errorHolder );
+		ok = ok & checkParameter( lSettings, KEY_RADIUS_Z, Double.class, errorHolder );
+		ok = ok & checkParameter( lSettings, KEY_THRESHOLD, Double.class, errorHolder );
+		ok = ok & checkParameter( lSettings, KEY_DO_SUBPIXEL_LOCALIZATION, Boolean.class, errorHolder );
+		ok = ok & checkParameter( lSettings, KEY_NORMALIZE, Boolean.class, errorHolder );
+		final List< String > mandatoryKeys = new ArrayList<>();
+		mandatoryKeys.add( KEY_TARGET_CHANNEL );
+		mandatoryKeys.add( KEY_RADIUS );
+		mandatoryKeys.add( KEY_RADIUS_Z );
+		mandatoryKeys.add( KEY_THRESHOLD );
+		mandatoryKeys.add( KEY_DO_SUBPIXEL_LOCALIZATION );
+		mandatoryKeys.add( KEY_NORMALIZE );
+		ok = ok & checkMapKeys( lSettings, mandatoryKeys, null, errorHolder );
+		if ( !ok )
+			errorMessage = errorHolder.toString();
+		return ok;
+	}
+
+	@Override
+	public boolean marshall( final Map< String, Object > lSettings, final Element element )
+	{
+		final StringBuilder errorHolder = new StringBuilder();
+		final boolean ok = writeTargetChannel( lSettings, element, errorHolder )
+				&& writeRadius( lSettings, element, errorHolder )
+				&& writeAttribute( lSettings, element, KEY_RADIUS_Z, Double.class, errorHolder )
+				&& writeThreshold( lSettings, element, errorHolder )
+				&& writeAttribute( lSettings, element, KEY_NORMALIZE, Boolean.class, errorHolder )
+				&& writeDoSubPixel( lSettings, element, errorHolder );
+		if ( !ok )
+			errorMessage = errorHolder.toString();
+		return ok;
+	}
+
+	@Override
+	public boolean unmarshall( final Element element, final Map< String, Object > lSettings )
+	{
+		lSettings.clear();
+		final StringBuilder errorHolder = new StringBuilder();
+		boolean ok = true;
+		ok = ok & readDoubleAttribute( element, lSettings, KEY_RADIUS, errorHolder );
+		ok = ok & readDoubleAttribute( element, lSettings, KEY_RADIUS_Z, errorHolder );
+		ok = ok & readDoubleAttribute( element, lSettings, KEY_THRESHOLD, errorHolder );
+		ok = ok & readBooleanAttribute( element, lSettings, KEY_DO_SUBPIXEL_LOCALIZATION, errorHolder );
+		ok = ok & readBooleanAttribute( element, lSettings, KEY_NORMALIZE, errorHolder );
+		ok = ok & readIntegerAttribute( element, lSettings, KEY_TARGET_CHANNEL, errorHolder );
+		if ( !ok )
+		{
+			errorMessage = errorHolder.toString();
+			return false;
+		}
+		return checkSettings( lSettings );
+	}
+
+	@Override
+	public ConfigurationPanel getDetectorConfigurationPanel( final Settings lSettings, final Model model )
+	{
+		return new HessianDetectorConfigurationPanel( lSettings, model, INFO_TEXT, NAME );
+	}
+
+	@Override
+	public String getInfoText()
+	{
+		return INFO_TEXT;
+	}
+
+	@Override
+	public String getName()
+	{
+		return NAME;
+	}
+
+	@Override
+	public Map< String, Object > getDefaultSettings()
+	{
+		final Map< String, Object > lSettings = super.getDefaultSettings();
+		lSettings.remove( KEY_DO_MEDIAN_FILTERING );
+		lSettings.put( KEY_RADIUS_Z, DEFAULT_RADIUS_Z );
+		lSettings.put( KEY_NORMALIZE, DEFAULT_NORMALIZE );
+		return lSettings;
+	}
+
+	@Override
+	public HessianDetectorFactory< T > copy()
+	{
+		return new HessianDetectorFactory< >();
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetectorFactory.java
@@ -106,6 +106,12 @@ public class HessianDetectorFactory< T extends RealType< T > & NativeType< T > >
 	}
 
 	@Override
+	public boolean forbidMultithreading()
+	{
+		return true;
+	}
+
+	@Override
 	public String getKey()
 	{
 		return DETECTOR_KEY;

--- a/src/main/java/fiji/plugin/trackmate/detection/LogDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/LogDetectorFactory.java
@@ -61,6 +61,7 @@ import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
@@ -106,10 +107,10 @@ public class LogDetectorFactory< T extends RealType< T > & NativeType< T >> impl
 	}
 	
 	
-	protected RandomAccessible< T > prepareFrameImg( final int frame )
+	protected RandomAccessibleInterval< T > prepareFrameImg( final int frame )
 	{
 		final double[] calibration = TMUtils.getSpatialCalibration( img );
-		RandomAccessible< T > imFrame;
+		RandomAccessibleInterval< T > imFrame;
 		final int cDim = img.dimensionIndex( Axes.CHANNEL );
 		if ( cDim < 0 )
 		{

--- a/src/main/java/fiji/plugin/trackmate/gui/components/LogPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/LogPanel.java
@@ -31,7 +31,9 @@ import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
 import javax.swing.SwingUtilities;
+import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
@@ -133,6 +135,8 @@ public class LogPanel extends JPanel
 	private class LogPanelLogger extends Logger
 	{
 
+		protected static final int MAX_N_CHARS = 10_000;
+
 		@Override
 		public void error( final String message )
 		{
@@ -149,8 +153,24 @@ public class LogPanel extends JPanel
 				{
 					final StyleContext sc = StyleContext.getDefaultStyleContext();
 					final AttributeSet aset = sc.addAttribute( SimpleAttributeSet.EMPTY, StyleConstants.Foreground, color );
-					final int len = textPane.getDocument().getLength();
-					textPane.setCaretPosition( len );
+					final AbstractDocument doc = ( AbstractDocument ) textPane.getStyledDocument();
+					final int len = doc.getLength();
+					final int l = message.length();
+				
+
+					if ( len + l > MAX_N_CHARS )
+					{
+						final int delta = Math.max( 0, Math.min( l - 1, len + l - MAX_N_CHARS ) );
+						try
+						{
+							doc.remove( 0, delta );
+						}
+						catch ( final BadLocationException e )
+						{
+							e.printStackTrace();
+						}
+					}
+					textPane.setCaretPosition( doc.getLength() );
 					textPane.setCharacterAttributes( aset, false );
 					textPane.replaceSelection( message );
 				}

--- a/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
@@ -1,0 +1,415 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2022 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package fiji.plugin.trackmate.gui.components.detector;
+
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_DO_SUBPIXEL_LOCALIZATION;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_NORMALIZE;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_RADIUS;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_RADIUS_Z;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_TARGET_CHANNEL;
+import static fiji.plugin.trackmate.detection.DetectorKeys.KEY_THRESHOLD;
+import static fiji.plugin.trackmate.gui.Fonts.BIG_FONT;
+import static fiji.plugin.trackmate.gui.Fonts.FONT;
+import static fiji.plugin.trackmate.gui.Fonts.SMALL_FONT;
+import static fiji.plugin.trackmate.gui.Icons.PREVIEW_ICON;
+
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFormattedTextField;
+import javax.swing.JLabel;
+import javax.swing.JSlider;
+import javax.swing.SwingConstants;
+
+import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Settings;
+import fiji.plugin.trackmate.detection.DetectionUtils;
+import fiji.plugin.trackmate.detection.HessianDetectorFactory;
+import fiji.plugin.trackmate.detection.LogDetectorFactory;
+import fiji.plugin.trackmate.gui.GuiUtils;
+import fiji.plugin.trackmate.gui.components.ConfigurationPanel;
+import fiji.plugin.trackmate.util.JLabelLogger;
+
+/**
+ * Configuration panel the Hessian detector.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class HessianDetectorConfigurationPanel extends ConfigurationPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String TOOLTIP_PREVIEW = "<html>"
+			+ "Preview the current settings on the current frame."
+			+ "<p>"
+			+ "Advice: change the settings until you get at least <br>"
+			+ "<b>all</b> the spots you want, and do not mind the <br>"
+			+ "spurious spots too much. You will get a chance to <br>"
+			+ "get rid of them later."
+			+ "</html>";
+
+	private static final NumberFormat FORMAT = new DecimalFormat( "#.###" );
+
+	private final JFormattedTextField ftfQualityThreshold;
+
+	private final JCheckBox jCheckBoxNormalize;
+
+	private final JFormattedTextField ftfDiameter;
+
+	private final JFormattedTextField ftfDiameterZ;
+
+	private final JCheckBox jCheckSubPixel;
+
+	private final JSlider sliderChannel;
+
+	/*
+	 * CONSTRUCTOR
+	 */
+
+	/**
+	 * Creates a new {@link LogDetectorConfigurationPanel}, a GUI able to
+	 * configure settings suitable to {@link LogDetectorFactory} and derived
+	 * implementations.
+	 *
+	 * @param settings
+	 *            the {@link Settings} object to get the source image from as
+	 *            well as physical calibration date and target interval.
+	 * @param model
+	 *            the {@link Model} that will be fed with the preview results.
+	 *            It is the responsibility of the views registered to listen to
+	 *            model change to display the preview results.
+	 * @param infoText
+	 *            the detector info text, will be displayed on the panel.
+	 * @param detectorName
+	 *            the detector name, will be displayed on the panel.
+	 */
+	public HessianDetectorConfigurationPanel( final Settings settings, final Model model, final String infoText, final String detectorName )
+	{
+		this.setPreferredSize( new java.awt.Dimension( 300, 461 ) );
+		final GridBagLayout gridBagLayout = new GridBagLayout();
+		gridBagLayout.columnWeights = new double[] { 0.0, 0.0, 1.0, 0.0 };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
+		setLayout( gridBagLayout );
+
+		final JLabel jLabelPreTitle = new JLabel();
+		final GridBagConstraints gbcLabelPreTitle = new GridBagConstraints();
+		gbcLabelPreTitle.anchor = GridBagConstraints.NORTH;
+		gbcLabelPreTitle.fill = GridBagConstraints.HORIZONTAL;
+		gbcLabelPreTitle.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelPreTitle.gridwidth = 4;
+		gbcLabelPreTitle.gridx = 0;
+		gbcLabelPreTitle.gridy = 0;
+		this.add( jLabelPreTitle, gbcLabelPreTitle );
+		jLabelPreTitle.setText( "Settings for detector:" );
+		jLabelPreTitle.setFont( FONT );
+
+		final JLabel jLabelSegmenterName = new JLabel();
+		final GridBagConstraints gbcLabelSegmenterName = new GridBagConstraints();
+		gbcLabelSegmenterName.anchor = GridBagConstraints.NORTH;
+		gbcLabelSegmenterName.fill = GridBagConstraints.HORIZONTAL;
+		gbcLabelSegmenterName.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelSegmenterName.gridwidth = 4;
+		gbcLabelSegmenterName.gridx = 0;
+		gbcLabelSegmenterName.gridy = 1;
+		this.add( jLabelSegmenterName, gbcLabelSegmenterName );
+		jLabelSegmenterName.setFont( BIG_FONT );
+		jLabelSegmenterName.setText( detectorName );
+
+		final JLabel jLabelHelpText = new JLabel();
+		final GridBagConstraints gbcLabelHelpText = new GridBagConstraints();
+		gbcLabelHelpText.fill = GridBagConstraints.BOTH;
+		gbcLabelHelpText.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelHelpText.gridwidth = 4;
+		gbcLabelHelpText.gridx = 0;
+		gbcLabelHelpText.gridy = 2;
+		this.add( jLabelHelpText, gbcLabelHelpText );
+		jLabelHelpText.setFont( FONT.deriveFont( Font.ITALIC ) );
+		jLabelHelpText.setText( infoText.replace( "<br>", "" ).replace( "<p>", "<p align=\"justify\">" ).replace( "<html>", "<html><p align=\"justify\">" ) );
+
+		final JLabel lblSegmentInChannel = new JLabel( "Detect in channel:" );
+		lblSegmentInChannel.setFont( SMALL_FONT );
+		final GridBagConstraints gbcSegmentInChannel = new GridBagConstraints();
+		gbcSegmentInChannel.gridwidth = 2;
+		gbcSegmentInChannel.anchor = GridBagConstraints.EAST;
+		gbcSegmentInChannel.insets = new Insets( 5, 5, 5, 5 );
+		gbcSegmentInChannel.gridx = 0;
+		gbcSegmentInChannel.gridy = 4;
+		add( lblSegmentInChannel, gbcSegmentInChannel );
+
+		sliderChannel = new JSlider();
+		final GridBagConstraints gbc_sliderChannel = new GridBagConstraints();
+		gbc_sliderChannel.fill = GridBagConstraints.BOTH;
+		gbc_sliderChannel.insets = new Insets( 5, 5, 5, 5 );
+		gbc_sliderChannel.gridx = 2;
+		gbc_sliderChannel.gridy = 4;
+		add( sliderChannel, gbc_sliderChannel );
+
+		final JLabel labelChannel = new JLabel( "1" );
+		labelChannel.setHorizontalAlignment( SwingConstants.CENTER );
+		labelChannel.setFont( SMALL_FONT );
+		final GridBagConstraints gbcLabelChannel = new GridBagConstraints();
+		gbcLabelChannel.anchor = GridBagConstraints.WEST;
+		gbcLabelChannel.fill = GridBagConstraints.VERTICAL;
+		gbcLabelChannel.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelChannel.gridx = 3;
+		gbcLabelChannel.gridy = 4;
+		add( labelChannel, gbcLabelChannel );
+
+		final JLabel jLabelEstimDiameter = new JLabel();
+		final GridBagConstraints gbc_jLabel2 = new GridBagConstraints();
+		gbc_jLabel2.anchor = GridBagConstraints.EAST;
+		gbc_jLabel2.insets = new Insets( 5, 5, 5, 5 );
+		gbc_jLabel2.gridwidth = 2;
+		gbc_jLabel2.gridx = 0;
+		gbc_jLabel2.gridy = 5;
+		this.add( jLabelEstimDiameter, gbc_jLabel2 );
+		jLabelEstimDiameter.setText( "Estimated object diameter in X & Y:" );
+		jLabelEstimDiameter.setFont( SMALL_FONT );
+
+		ftfDiameter = new JFormattedTextField( FORMAT );
+		ftfDiameter.setHorizontalAlignment( SwingConstants.CENTER );
+		ftfDiameter.setValue( Double.valueOf( 10. ) );
+		final GridBagConstraints gbcTextFieldBlobDiameter = new GridBagConstraints();
+		gbcTextFieldBlobDiameter.anchor = GridBagConstraints.SOUTH;
+		gbcTextFieldBlobDiameter.fill = GridBagConstraints.HORIZONTAL;
+		gbcTextFieldBlobDiameter.insets = new Insets( 5, 5, 5, 5 );
+		gbcTextFieldBlobDiameter.gridx = 2;
+		gbcTextFieldBlobDiameter.gridy = 5;
+		this.add( ftfDiameter, gbcTextFieldBlobDiameter );
+		ftfDiameter.setFont( SMALL_FONT );
+
+		final JLabel jLabelBlobDiameterUnit = new JLabel();
+		final GridBagConstraints gbcLabelBlobDiameterUnit = new GridBagConstraints();
+		gbcLabelBlobDiameterUnit.fill = GridBagConstraints.BOTH;
+		gbcLabelBlobDiameterUnit.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelBlobDiameterUnit.gridx = 3;
+		gbcLabelBlobDiameterUnit.gridy = 5;
+		this.add( jLabelBlobDiameterUnit, gbcLabelBlobDiameterUnit );
+		jLabelBlobDiameterUnit.setFont( SMALL_FONT );
+		jLabelBlobDiameterUnit.setText( model.getSpaceUnits() );
+
+		final JLabel jLabelEstimDiameterZ = new JLabel( "Estimated object diameter in Z:" );
+		jLabelEstimDiameterZ.setFont( SMALL_FONT );
+		final GridBagConstraints gbcLabelEstimDiameterZ = new GridBagConstraints();
+		gbcLabelEstimDiameterZ.anchor = GridBagConstraints.EAST;
+		gbcLabelEstimDiameterZ.gridwidth = 2;
+		gbcLabelEstimDiameterZ.insets = new Insets( 5, 5, 5, 5 );
+		gbcLabelEstimDiameterZ.gridx = 0;
+		gbcLabelEstimDiameterZ.gridy = 6;
+		add( jLabelEstimDiameterZ, gbcLabelEstimDiameterZ );
+
+		ftfDiameterZ = new JFormattedTextField( FORMAT );
+		ftfDiameterZ.setText( "15" );
+		ftfDiameterZ.setFont( SMALL_FONT );
+		ftfDiameterZ.setHorizontalAlignment( SwingConstants.CENTER );
+		final GridBagConstraints gbcFtfDiameterZ = new GridBagConstraints();
+		gbcFtfDiameterZ.insets = new Insets( 5, 5, 5, 5 );
+		gbcFtfDiameterZ.fill = GridBagConstraints.HORIZONTAL;
+		gbcFtfDiameterZ.gridx = 2;
+		gbcFtfDiameterZ.gridy = 6;
+		add( ftfDiameterZ, gbcFtfDiameterZ );
+
+		final JLabel jLabelBlobDiameterUnitZ = new JLabel( model.getSpaceUnits() );
+		jLabelBlobDiameterUnitZ.setFont( SMALL_FONT );
+		final GridBagConstraints gbcLabelBlobDiameterUnitZ = new GridBagConstraints();
+		gbcLabelBlobDiameterUnitZ.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelBlobDiameterUnitZ.gridx = 3;
+		gbcLabelBlobDiameterUnitZ.gridy = 6;
+		add( jLabelBlobDiameterUnitZ, gbcLabelBlobDiameterUnitZ );
+
+		final JLabel jLabelThreshold = new JLabel();
+		jLabelThreshold.setText( "Quality threshold:" );
+		final GridBagConstraints gbcLabelThreshold = new GridBagConstraints();
+		gbcLabelThreshold.anchor = GridBagConstraints.EAST;
+		gbcLabelThreshold.insets = new Insets( 5, 5, 5, 5 );
+		gbcLabelThreshold.gridwidth = 2;
+		gbcLabelThreshold.gridx = 0;
+		gbcLabelThreshold.gridy = 7;
+		this.add( jLabelThreshold, gbcLabelThreshold );
+		jLabelThreshold.setFont( SMALL_FONT );
+
+		ftfQualityThreshold = new JFormattedTextField( FORMAT );
+		ftfQualityThreshold.setHorizontalAlignment( SwingConstants.CENTER );
+		ftfQualityThreshold.setValue( Double.valueOf( 0. ) );
+		final GridBagConstraints gbcTextFieldThreshold = new GridBagConstraints();
+		gbcTextFieldThreshold.fill = GridBagConstraints.BOTH;
+		gbcTextFieldThreshold.insets = new Insets( 5, 5, 5, 5 );
+		gbcTextFieldThreshold.gridx = 2;
+		gbcTextFieldThreshold.gridy = 7;
+		this.add( ftfQualityThreshold, gbcTextFieldThreshold );
+		ftfQualityThreshold.setFont( SMALL_FONT );
+
+		final JLabel lblNormalize = new JLabel( "Normalize quality values:" );
+		lblNormalize.setFont( SMALL_FONT );
+		final GridBagConstraints gbcPreProcess = new GridBagConstraints();
+		gbcPreProcess.gridwidth = 2;
+		gbcPreProcess.anchor = GridBagConstraints.EAST;
+		gbcPreProcess.insets = new Insets( 5, 5, 5, 5 );
+		gbcPreProcess.gridx = 0;
+		gbcPreProcess.gridy = 8;
+		add( lblNormalize, gbcPreProcess );
+
+		jCheckBoxNormalize = new JCheckBox();
+		final GridBagConstraints gbcCheckBoxNormalize = new GridBagConstraints();
+		gbcCheckBoxNormalize.anchor = GridBagConstraints.NORTH;
+		gbcCheckBoxNormalize.fill = GridBagConstraints.HORIZONTAL;
+		gbcCheckBoxNormalize.insets = new Insets( 5, 5, 5, 0 );
+		gbcCheckBoxNormalize.gridwidth = 2;
+		gbcCheckBoxNormalize.gridx = 2;
+		gbcCheckBoxNormalize.gridy = 8;
+		this.add( jCheckBoxNormalize, gbcCheckBoxNormalize );
+		jCheckBoxNormalize.setFont( FONT );
+
+		final JLabel lblSubPixelLoc = new JLabel( "Sub-pixel localization:" );
+		lblSubPixelLoc.setFont( SMALL_FONT );
+		final GridBagConstraints gbcSubPixelLoc = new GridBagConstraints();
+		gbcSubPixelLoc.anchor = GridBagConstraints.EAST;
+		gbcSubPixelLoc.gridwidth = 2;
+		gbcSubPixelLoc.insets = new Insets( 5, 5, 5, 5 );
+		gbcSubPixelLoc.gridx = 0;
+		gbcSubPixelLoc.gridy = 9;
+		add( lblSubPixelLoc, gbcSubPixelLoc );
+
+		// Add sub-pixel checkbox
+		jCheckSubPixel = new JCheckBox();
+		final GridBagConstraints gbcCheckSubPixel = new GridBagConstraints();
+		gbcCheckSubPixel.anchor = GridBagConstraints.NORTH;
+		gbcCheckSubPixel.fill = GridBagConstraints.HORIZONTAL;
+		gbcCheckSubPixel.insets = new Insets( 5, 5, 5, 0 );
+		gbcCheckSubPixel.gridwidth = 2;
+		gbcCheckSubPixel.gridx = 2;
+		gbcCheckSubPixel.gridy = 9;
+		this.add( jCheckSubPixel, gbcCheckSubPixel );
+		jCheckSubPixel.setFont( SMALL_FONT );
+
+		final JButton btnPreview = new JButton( "Preview", PREVIEW_ICON );
+		btnPreview.setToolTipText( TOOLTIP_PREVIEW );
+		final GridBagConstraints gbcBtnPreview = new GridBagConstraints();
+		gbcBtnPreview.anchor = GridBagConstraints.NORTHEAST;
+		gbcBtnPreview.insets = new Insets( 5, 5, 5, 0 );
+		gbcBtnPreview.gridwidth = 3;
+		gbcBtnPreview.gridx = 1;
+		gbcBtnPreview.gridy = 11;
+		this.add( btnPreview, gbcBtnPreview );
+		btnPreview.setFont( SMALL_FONT );
+
+		final JLabelLogger labelLogger = new JLabelLogger();
+		labelLogger.setText( "   " );
+		final GridBagConstraints gbcLabelLogger = new GridBagConstraints();
+		gbcLabelLogger.insets = new Insets( 5, 5, 0, 0 );
+		gbcLabelLogger.fill = GridBagConstraints.BOTH;
+		gbcLabelLogger.gridwidth = 4;
+		gbcLabelLogger.gridx = 0;
+		gbcLabelLogger.gridy = 12;
+		add( labelLogger, gbcLabelLogger );
+		final Logger localLogger = labelLogger.getLogger();
+
+		/*
+		 * Deal with channels: the slider and channel labels are only visible if
+		 * we find more than one channel.
+		 */
+		final int nChannels = settings.imp.getNChannels();
+		sliderChannel.setMaximum( nChannels );
+		sliderChannel.setMinimum( 1 );
+		sliderChannel.setValue( settings.imp.getChannel() );
+
+		if ( nChannels <= 1 )
+		{
+			labelChannel.setVisible( false );
+			lblSegmentInChannel.setVisible( false );
+			sliderChannel.setVisible( false );
+		}
+		else
+		{
+			labelChannel.setVisible( true );
+			lblSegmentInChannel.setVisible( true );
+			sliderChannel.setVisible( true );
+		}
+
+		/*
+		 * Listeners and stuff.
+		 */
+
+		sliderChannel.addChangeListener( e -> labelChannel.setText( "" + sliderChannel.getValue() ) );
+		btnPreview.addActionListener( e -> DetectionUtils.preview(
+				model,
+				settings,
+				new HessianDetectorFactory<>(),
+				getSettings(),
+				settings.imp.getFrame() - 1,
+				localLogger,
+				b -> btnPreview.setEnabled( b ) ) );
+		GuiUtils.selectAllOnFocus( ftfDiameter );
+		GuiUtils.selectAllOnFocus( ftfDiameterZ );
+		GuiUtils.selectAllOnFocus( ftfQualityThreshold );
+	}
+
+	/*
+	 * METHODS
+	 */
+
+	@Override
+	public Map< String, Object > getSettings()
+	{
+		final HashMap< String, Object > lSettings = new HashMap<>( 5 );
+		final int targetChannel = sliderChannel.getValue();
+		final double expectedRadius = ( ( Number ) ftfDiameter.getValue() ).doubleValue() / 2.;
+		final double expectedRadiusZ = ( ( Number ) ftfDiameterZ.getValue() ).doubleValue() / 2.;
+		final double qualityThreshold = ( ( Number ) ftfQualityThreshold.getValue() ).doubleValue();
+		final boolean normalize = jCheckBoxNormalize.isSelected();
+		final boolean doSubPixelLocalization = jCheckSubPixel.isSelected();
+		lSettings.put( KEY_TARGET_CHANNEL, targetChannel );
+		lSettings.put( KEY_RADIUS, expectedRadius );
+		lSettings.put( KEY_RADIUS_Z, expectedRadiusZ );
+		lSettings.put( KEY_THRESHOLD, qualityThreshold );
+		lSettings.put( KEY_NORMALIZE, normalize );
+		lSettings.put( KEY_DO_SUBPIXEL_LOCALIZATION, doSubPixelLocalization );
+		return lSettings;
+	}
+
+	@Override
+	public void setSettings( final Map< String, Object > settings )
+	{
+		sliderChannel.setValue( ( Integer ) settings.get( KEY_TARGET_CHANNEL ) );
+		final double radiusXY = ( Double ) settings.get( KEY_RADIUS );
+		final double radiusZ = ( Double ) settings.get( KEY_RADIUS_Z );
+		ftfDiameter.setValue( Double.valueOf( 2. * radiusXY ) );
+		ftfDiameterZ.setValue( Double.valueOf( 2. * radiusZ ) );
+		jCheckBoxNormalize.setSelected( ( Boolean ) settings.get( KEY_NORMALIZE ) );
+		ftfQualityThreshold.setValue( ( ( Number ) settings.get( KEY_THRESHOLD ) ).doubleValue() );
+		jCheckSubPixel.setSelected( ( Boolean ) settings.get( KEY_DO_SUBPIXEL_LOCALIZATION ) );
+	}
+
+	@Override
+	public void clean()
+	{}
+}

--- a/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
@@ -53,7 +53,6 @@ import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.detection.DetectionUtils;
 import fiji.plugin.trackmate.detection.HessianDetectorFactory;
-import fiji.plugin.trackmate.detection.LogDetectorFactory;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.gui.components.ConfigurationPanel;
 import fiji.plugin.trackmate.util.JLabelLogger;

--- a/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/detector/HessianDetectorConfigurationPanel.java
@@ -95,8 +95,8 @@ public class HessianDetectorConfigurationPanel extends ConfigurationPanel
 	 */
 
 	/**
-	 * Creates a new {@link LogDetectorConfigurationPanel}, a GUI able to
-	 * configure settings suitable to {@link LogDetectorFactory} and derived
+	 * Creates a new {@code HessianDetectorConfigurationPanel}, a GUI able to
+	 * configure settings suitable to {@code HessianDetector} and derived
 	 * implementations.
 	 *
 	 * @param settings

--- a/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/ExecuteDetectionDescriptor.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/ExecuteDetectionDescriptor.java
@@ -23,6 +23,7 @@ package fiji.plugin.trackmate.gui.wizard.descriptors;
 
 import org.scijava.Cancelable;
 
+import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.gui.components.LogPanel;
 import fiji.plugin.trackmate.gui.wizard.WizardPanelDescriptor;
@@ -45,6 +46,11 @@ public class ExecuteDetectionDescriptor extends WizardPanelDescriptor
 	public Runnable getForwardRunnable()
 	{
 		return () -> {
+
+			// Read ROI from imp NOW.
+			final Settings settings = trackmate.getSettings();
+			settings.setRoi( settings.imp.getRoi() );
+			// Exec detection.
 			final long start = System.currentTimeMillis();
 			final boolean ok = trackmate.execDetection();
 			if ( !ok )

--- a/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/StartDialogDescriptor.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/StartDialogDescriptor.java
@@ -105,15 +105,11 @@ public class StartDialogDescriptor extends WizardPanelDescriptor
 	{
 		// Copy the values in the panel to the settings object.
 		final RoiSettingsPanel panel = ( RoiSettingsPanel ) targetPanel;
-		settings.xstart = ( ( Number ) panel.tfXStart.getValue() ).intValue();
-		settings.xend = ( ( Number ) panel.tfXEnd.getValue() ).intValue();
-		settings.ystart = ( ( Number ) panel.tfYStart.getValue() ).intValue();
-		settings.yend = ( ( Number ) panel.tfYEnd.getValue() ).intValue();
+		settings.setRoi( settings.imp.getRoi() );
 		settings.zstart = ( ( Number ) panel.tfZStart.getValue() ).intValue();
 		settings.zend = ( ( Number ) panel.tfZEnd.getValue() ).intValue();
 		settings.tstart = ( ( Number ) panel.tfTStart.getValue() ).intValue();
 		settings.tend = ( ( Number ) panel.tfTEnd.getValue() ).intValue();
-		settings.roi = settings.imp.getRoi();
 		// Log
 		logger.log( "\nImage region of interest:\n", Logger.BLUE_COLOR );
 		logger.log( settings.toStringImageInfo() );
@@ -353,7 +349,7 @@ public class StartDialogDescriptor extends WizardPanelDescriptor
 			add( lblCropSetting, gbcLabelCropSetting );
 
 			tfXStart = new JFormattedTextField( Integer.valueOf( 0 ) );
-			GuiUtils.selectAllOnFocus( tfXStart );
+			tfXStart.setEnabled( false );
 			tfXStart.setHorizontalAlignment( SwingConstants.CENTER );
 			tfXStart.setPreferredSize( TEXTFIELD_DIMENSION );
 			tfXStart.setFont( SMALL_FONT );
@@ -366,7 +362,7 @@ public class StartDialogDescriptor extends WizardPanelDescriptor
 			add( tfXStart, gbcTextFieldXStart );
 
 			tfXEnd = new JFormattedTextField( Integer.valueOf( 0 ) );
-			GuiUtils.selectAllOnFocus( tfXEnd );
+			tfXEnd.setEnabled( false );
 			tfXEnd.setHorizontalAlignment( SwingConstants.CENTER );
 			tfXEnd.setPreferredSize( TEXTFIELD_DIMENSION );
 			tfXEnd.setFont( SMALL_FONT );
@@ -413,7 +409,7 @@ public class StartDialogDescriptor extends WizardPanelDescriptor
 			add( jLabelTo3, gbcLabelTo3 );
 
 			tfYStart = new JFormattedTextField( Integer.valueOf( 0 ) );
-			GuiUtils.selectAllOnFocus( tfYStart );
+			tfYStart.setEnabled( false );
 			tfYStart.setHorizontalAlignment( SwingConstants.CENTER );
 			tfYStart.setPreferredSize( TEXTFIELD_DIMENSION );
 			tfYStart.setFont( SMALL_FONT );
@@ -443,7 +439,7 @@ public class StartDialogDescriptor extends WizardPanelDescriptor
 			add( jLabelZ, gbcLabelZ );
 
 			tfYEnd = new JFormattedTextField( Integer.valueOf( 0 ) );
-			GuiUtils.selectAllOnFocus( tfYEnd );
+			tfYEnd.setEnabled( false );
 			tfYEnd.setHorizontalAlignment( SwingConstants.CENTER );
 			tfYEnd.setPreferredSize( TEXTFIELD_DIMENSION );
 			tfYEnd.setFont( SMALL_FONT );

--- a/src/main/java/fiji/plugin/trackmate/io/TmXmlReader.java
+++ b/src/main/java/fiji/plugin/trackmate/io/TmXmlReader.java
@@ -31,10 +31,6 @@ import static fiji.plugin.trackmate.io.TmXmlKeys.ANALYZER_COLLECTION_ELEMENT_KEY
 import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_ELEMENT_KEY;
 import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_TEND_ATTRIBUTE_NAME;
 import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_TSTART_ATTRIBUTE_NAME;
-import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_XEND_ATTRIBUTE_NAME;
-import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_XSTART_ATTRIBUTE_NAME;
-import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_YEND_ATTRIBUTE_NAME;
-import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_YSTART_ATTRIBUTE_NAME;
 import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_ZEND_ATTRIBUTE_NAME;
 import static fiji.plugin.trackmate.io.TmXmlKeys.CROP_ZSTART_ATTRIBUTE_NAME;
 import static fiji.plugin.trackmate.io.TmXmlKeys.DETECTOR_SETTINGS_ELEMENT_KEY;
@@ -728,10 +724,6 @@ public class TmXmlReader
 		final Element settingsEl = settingsElement.getChild( CROP_ELEMENT_KEY );
 		if ( null != settingsEl )
 		{
-			settings.xstart = readIntAttribute( settingsEl, CROP_XSTART_ATTRIBUTE_NAME, logger, 1 );
-			settings.xend = readIntAttribute( settingsEl, CROP_XEND_ATTRIBUTE_NAME, logger, 512 );
-			settings.ystart = readIntAttribute( settingsEl, CROP_YSTART_ATTRIBUTE_NAME, logger, 1 );
-			settings.yend = readIntAttribute( settingsEl, CROP_YEND_ATTRIBUTE_NAME, logger, 512 );
 			settings.zstart = readIntAttribute( settingsEl, CROP_ZSTART_ATTRIBUTE_NAME, logger, 1 );
 			settings.zend = readIntAttribute( settingsEl, CROP_ZEND_ATTRIBUTE_NAME, logger, 10 );
 			settings.tstart = readIntAttribute( settingsEl, CROP_TSTART_ATTRIBUTE_NAME, logger, 1 );

--- a/src/main/java/fiji/plugin/trackmate/io/TmXmlWriter.java
+++ b/src/main/java/fiji/plugin/trackmate/io/TmXmlWriter.java
@@ -321,10 +321,10 @@ public class TmXmlWriter
 	private Element echoCropSettings( final Settings settings )
 	{
 		final Element settingsElement = new Element( CROP_ELEMENT_KEY );
-		settingsElement.setAttribute( CROP_XSTART_ATTRIBUTE_NAME, "" + settings.xstart );
-		settingsElement.setAttribute( CROP_XEND_ATTRIBUTE_NAME, "" + settings.xend );
-		settingsElement.setAttribute( CROP_YSTART_ATTRIBUTE_NAME, "" + settings.ystart );
-		settingsElement.setAttribute( CROP_YEND_ATTRIBUTE_NAME, "" + settings.yend );
+		settingsElement.setAttribute( CROP_XSTART_ATTRIBUTE_NAME, "" + settings.getXstart() );
+		settingsElement.setAttribute( CROP_XEND_ATTRIBUTE_NAME, "" + settings.getXend() );
+		settingsElement.setAttribute( CROP_YSTART_ATTRIBUTE_NAME, "" + settings.getYstart() );
+		settingsElement.setAttribute( CROP_YEND_ATTRIBUTE_NAME, "" + settings.getYend() );
 		settingsElement.setAttribute( CROP_ZSTART_ATTRIBUTE_NAME, "" + settings.zstart );
 		settingsElement.setAttribute( CROP_ZEND_ATTRIBUTE_NAME, "" + settings.zend );
 		settingsElement.setAttribute( CROP_TSTART_ATTRIBUTE_NAME, "" + settings.tstart );

--- a/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
@@ -554,13 +554,13 @@ public class TMUtils
 
 		// X, we must have it.
 		final int xindex = img.dimensionIndex( Axes.X );
-		min[ xindex ] = settings.xstart;
-		max[ xindex ] = settings.xend;
+		min[ xindex ] = settings.getXstart();
+		max[ xindex ] = settings.getXend();
 
 		// Y, we must have it.
 		final int yindex = img.dimensionIndex( Axes.Y );
-		min[ yindex ] = settings.ystart;
-		max[ yindex ] = settings.yend;
+		min[ yindex ] = settings.getYstart();
+		max[ yindex ] = settings.getYend();
 
 		// Z, we MIGHT have it.
 		final int zindex = img.dimensionIndex( Axes.Z );
@@ -635,13 +635,13 @@ public class TMUtils
 
 		// X, we must have it.
 		final int xindex = img.dimensionIndex( Axes.X );
-		min[ xindex ] = settings.xstart;
-		max[ xindex ] = settings.xend;
+		min[ xindex ] = settings.getXstart();
+		max[ xindex ] = settings.getXend();
 
 		// Y, we must have it.
 		final int yindex = img.dimensionIndex( Axes.Y );
-		min[ yindex ] = settings.ystart;
-		max[ yindex ] = settings.yend;
+		min[ yindex ] = settings.getYstart();
+		max[ yindex ] = settings.getYend();
 
 		// Z, we MIGHT have it.
 		final int zindex = img.dimensionIndex( Axes.Z );

--- a/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive1.java
+++ b/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive1.java
@@ -1,0 +1,83 @@
+package fiji.plugin.trackmate.detection;
+
+import java.util.List;
+
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.SelectionModel;
+import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.SpotCollection;
+import fiji.plugin.trackmate.features.FeatureUtils;
+import fiji.plugin.trackmate.gui.GuiUtils;
+import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings;
+import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings.TrackMateObject;
+import fiji.plugin.trackmate.gui.displaysettings.DisplaySettingsIO;
+import fiji.plugin.trackmate.util.TMUtils;
+import fiji.plugin.trackmate.visualization.hyperstack.HyperStackDisplayer;
+import ij.IJ;
+import ij.ImageJ;
+import ij.ImagePlus;
+import net.imagej.ImgPlus;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+public class HessianDetectorTestDrive1
+{
+
+	public static < T extends RealType< T > & NativeType< T > > void main( final String[] args )
+	{
+		ImageJ.main( args );
+		GuiUtils.setSystemLookAndFeel();
+
+//			final ImagePlus imp = IJ.openImage( "samples/Celegans-5pc-17timepoints-t13.tif" );
+		final ImagePlus imp = IJ.openImage( "samples/TSabateCell.tif" );
+		imp.show();
+
+		@SuppressWarnings( "unchecked" )
+		final ImgPlus< T > input = TMUtils.rawWraps( imp );
+		final double[] calibration = TMUtils.getSpatialCalibration( imp );
+		final double radiusXY = 0.6 / 2.; // um;
+		final double radiusZ = 1.6 / 2.;
+		final double threshold = 0.2;
+		final boolean normalize = true; // scale quality to 0 - 1.
+
+		final HessianDetector< T > detector = new HessianDetector<>(
+				Views.extendMirrorDouble( input ),
+				input,
+				calibration,
+				radiusXY,
+				radiusZ,
+				threshold,
+				normalize,
+				true );
+		if ( !detector.checkInput() || !detector.process() )
+		{
+			System.err.println( "Processing failed:\n" + detector.getErrorMessage() );
+			return;
+		}
+
+		final List< Spot > spots = detector.getResult();
+		spots.sort( Spot.featureComparator( Spot.QUALITY ) );
+		spots.forEach( s -> System.out.println( String.format( " - %3d: Q = %7.3f, L = %s",
+				s.ID(),
+				s.getFeature( Spot.QUALITY ),
+				Util.printCoordinates( s ) ) ) );
+
+		final SpotCollection sc = new SpotCollection();
+		sc.put( 0, spots );
+		sc.setVisible( true );
+		final Model model = new Model();
+		model.setPhysicalUnits( imp.getCalibration().getUnit(), imp.getCalibration().getTimeUnit() );
+		model.setSpots( sc, false );
+		final SelectionModel selectionModel = new SelectionModel( model );
+		final DisplaySettings ds = DisplaySettingsIO.readUserDefault();
+		final String feature = Spot.QUALITY;
+		ds.setSpotColorBy( TrackMateObject.SPOTS, feature );
+		final double[] mm = FeatureUtils.autoMinMax( model, TrackMateObject.SPOTS, feature );
+		ds.setSpotMinMax( mm[ 0 ], mm[ 1 ] );
+		final HyperStackDisplayer displayer = new HyperStackDisplayer( model, selectionModel, imp, ds );
+		displayer.render();
+		displayer.refresh();
+	}
+}

--- a/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive2.java
+++ b/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive2.java
@@ -1,0 +1,17 @@
+package fiji.plugin.trackmate.detection;
+
+import fiji.plugin.trackmate.TrackMatePlugIn;
+import fiji.plugin.trackmate.gui.GuiUtils;
+import ij.ImageJ;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+
+public class HessianDetectorTestDrive2
+{
+	public static < T extends RealType< T > & NativeType< T > > void main( final String[] args )
+	{
+		ImageJ.main( args );
+		GuiUtils.setSystemLookAndFeel();
+		new TrackMatePlugIn().run( "samples/TSabateCell-movie.tif" );
+	}
+}

--- a/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive2.java
+++ b/src/test/java/fiji/plugin/trackmate/detection/HessianDetectorTestDrive2.java
@@ -3,6 +3,7 @@ package fiji.plugin.trackmate.detection;
 import fiji.plugin.trackmate.TrackMatePlugIn;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import ij.ImageJ;
+import ij.plugin.frame.RoiManager;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
@@ -12,6 +13,8 @@ public class HessianDetectorTestDrive2
 	{
 		ImageJ.main( args );
 		GuiUtils.setSystemLookAndFeel();
-		new TrackMatePlugIn().run( "samples/TSabateCell-movie.tif" );
+		final RoiManager roiManager = RoiManager.getRoiManager();
+		roiManager.runCommand( "Open", "samples/20220131-1435_Lv4TetOinCuO-C4_t-000-106_p005.ome_ALN_MarginsCropped-rois2.zip" );
+		new TrackMatePlugIn().run( "samples/20220131-1435_Lv4TetOinCuO-C4_t-000-106_p005.ome_ALN_MarginsCropped-2.tif" );
 	}
 }


### PR DESCRIPTION
## A. Principle.

Sometimes one needs to detect bright spots that are not very bright, in a low SNR image, with a lot of unspecific signal:

![image](https://user-images.githubusercontent.com/3583203/172461094-492c8e58-302d-4ef1-8449-d99cd82a39cf.png)

In the image above, we observe a rather strong non-specific signal in the whole nuclei. The intensity of this non-specific signal versus the background is close to the intensity of the spot signal versus the non-specific signal. Even the nucleus in the image does not look happy about it.

The non-specific signal generates clear and sharp edges at the border of the nucleus, which is picked-up by the LoG detector, with unfortunately a high quality. Our goal is to come up with a better detector, with a better edge response elimination. After some tests I came up with a detector based on the determinant of the Hessian matrix.

The Hessian matrix of an image is a tensor made of the combinations of the 2nd derivatives of the intensity in all directions at each pixel of the source image. So, if f is the intensity, we have at each pixel:

![image](https://user-images.githubusercontent.com/3583203/172461303-5a9ad336-0188-46ba-a3ad-149f92e56804.png)

(Note that it is a real, symmetric matrix.) This matrix measures the ‘local curvature’ of the intensity. In a hand-waving explanation, let’s suppose we work in 2D and that the intensity is actually the height of a surface. And let’s consider the height variation in only the 2 principal directions, that we suppose are aligned with the X and Y axes. A bright spot in the source image corresponds to a sharp peak in our surface analogy. At the top of this peak, the curvature is high in absolute value along X and negative: the height increases a lot then decreases immediately after the peak. So, the curvature `hxx` has a large absolute value. The same along the Y direction.

Let’s suppose now we compute the curvature not on a peak, but on a bright line aligned with the Y axis. In this case the curvature is still high along the X axis: When we cross the line, the height increases and decreases immediately. But along the Y axis, the as we follow the line, the height does not change and the curvature is 0. If we have an edge along the Y axis instead of a line, the situation is the same: the curvature is high when we cross the edge along X, but 0 along Y.

If we now extend our analogy to a surface mapped in 3D, we still have peaks and lines in 3D, but also have planes and plateaus. Let’s suppose we have a plane aligned with YZ. In this case the intensity changes a lot when we cross it following the X axis, so the curvature `hxx` is high. As we follow the plane along Y and X, the curvatures `hyy` and `hzz` are 0. The same for a plateau aligned with YZ.

In summary, in 3D, if we consider the absolute values of the 3 variables `hxx`, `hyy` and `hzz`:
- The 3 values are high in absolute value for a bright peak.
- Two of them are small for a plane or plateau.
- One of them is small for a line or an edge.
- In a homogeneous region of the image, all of them are small.

We can therefore build a spot detector that exploit this fact by taking the product of the 3 curvatures. The product will be comparatively higher only for locations at which we have a bright spot, and should offer a much lower value for plateaus and edges. The analogy above works if the principal directions are aligned with the X, Y and Z axes. When they are not, we can diagonalize the Hessian matrix (we can, it is real and symmetric) and use the eigenvalues instead. But since we are computing the product of the eigenvalues, we can take the determinant of the matrix and skip the diagonalization step to be faster. 

The new detector is based on this calculation:
https://github.com/fiji/TrackMate/blob/hessian-detector/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java#L146-L228

This idea is absolutely not new. Lindeberg [1] already proposed it in the 90s along the LoG detector we have been using so far. I merely extended it to 3D. Mikolajczyk and Schmidt [2] noted that the determinant of the Hessian has indeed a stronger specificity to blobs in images with many spurious structures. Also, if this new detector is based on the product of the eigenvalues (determinant of H), the LoG detector is based on the sum of the eigenvalues (trace of H).


## B. In TrackMate.

TrackMate will show a new detector with a specific configuration panel:

![image](https://user-images.githubusercontent.com/3583203/172461978-f9708b0c-687d-41a8-bf97-6cb43fa186f3.png)
![image](https://user-images.githubusercontent.com/3583203/172461983-de696f90-fa15-4bcb-a81f-b23fc0ba36a0.png)

### Spot size in XY and Z.

This detector allows configuring a different size of spots in XY and Z, to account or the elongation along Z. 

### Normalizing the quality value.

Also, there is a checkbox that normalizes all the pixel values of the Hessian determinant image between 0 and 1 for each time-point separately. With this checked, the spot with the highest quality will have a quality of 1. (It is possible that it gets a lower quality if you use a complex region of interest where a bright spot would be in the bounding box of the ROI, but outside the ROI.)

This will help dealing with the high bleaching we observe. Indeed, here is an example of a movie where we have bleaching. If we look at the mean intensity over time, we get this:

![image](https://user-images.githubusercontent.com/3583203/172462235-726c64ec-6062-4221-992f-0c1563b9a2b8.png)

The mean intensity is divided by 5 from start to end, so if set a threshold on quality based on the first time-point, it is likely that we will miss relevant spots at later time-points. Inversely, if we set a threshold based on later time-point, we will have many spurious spots in the first time-points that will complicate tracking later on. If you select the ‘normalize’ option, all spots will have a quality that ranges from 0 to 1 in all time-points, which will mitigate the negative impact of bleaching.

### The Hessian detector can process ROIs separately.

This is super important, in particular in conjunction with the quality normalization above.
If you have the ROI manager open when you use the Hessian detector, it will treat each ROI in the list separately, and ignore part of the images that are not in a ROI.
This is incredibly useful for instance when tracking individual spots inside multiple cells in the field-of-view, as illustrated below:
![image](https://user-images.githubusercontent.com/3583203/172463514-0528a1ac-17ba-406f-a231-97732c2dad5a.png)

Or like this:
![image](https://user-images.githubusercontent.com/3583203/172463611-d6b560a7-bed7-4746-b2ac-ebda52b9c3bf.png)



## C. Basic comparison with the LoG detector.

Now we want to check whether the Hessian detector is indeed more specific than the LoG detector. What you will see below use the parameters in the image above. I selected the Z slice in which
the spot we are tracking is present. Below you can see the results of the LoG filter (left) and the Hessian determinant (right), computed on the single cell shown above and with min & max display set from 0 to 1 and with the ‘fire’ LUT:

![image](https://user-images.githubusercontent.com/3583203/172462477-191d84db-8ca7-4c74-873d-803d3b49857a.png)
![image](https://user-images.githubusercontent.com/3583203/172462493-01cca372-ec37-42f2-8834-2b6e4e5c7b5b.png)

Both filtered images display a strong response at the spot location. However, it is clear that the LoG image has also a strong response in many other places. For instance, we observe a strong response near the edges of the nucleus. We also observe intermediate response inside the nucleus, that tends to increase local contrast this way. The Hessian image however is very specific. We only see one bright spot, and a few faint dots on the edge border. But these spurious dots are far less intense than their LoG counterpart, and they will therefore yield spots with a very low quality, making it easy to filter them out. This is confirmed by looking at the histogram of the two filtered images:

![image](https://user-images.githubusercontent.com/3583203/172462536-295f3663-60cb-447c-9d0b-0a62393be1a7.png)
![image](https://user-images.githubusercontent.com/3583203/172462548-d76b3b82-3a36-424c-ae65-a145b343ef2d.png)

The histogram for the LoG image is very broad, while the ones from the Hessian determinant is thin. The spot quality values will be taken from the histogram, and we see that it will be easier to separate the few real spots from spurious ones on the Hessian determinant histogram. (This illustration with the histograms is inaccurate, there is not a single bin per spot, but it gives an idea.)


## D. Limitations.

Also, the Hessian detector is much more demanding in terms of memory. The LoG computation can be expressed in terms of linear filtering, and uses just one convolution. To compute the Hessian matrix, we need to have the following intermediate images (in 3D):
- If the region of interest (ROI) in the source image is W x H x D pixels with 16-bit values.
- The computation of the gradients requires 3 images of size W x H x D pixels with 32-bit values (computation on floats).
- The computation of the Hessian requires one image of size W x H x D x 6 pixels with 32-bit values. The last dimension is used to store the second derivative. Because the Hessian matrix is symmetric, we only need to store the 6 elements of the upper triangular matrix.
- The determinant of the Hessian requires a storage of W x H x D pixels with 32-bit values.

The gradient image and the Hessian tensor are discarded once the determinant is calculated. But they might be large enough so that it is wide not to process several time-points in parallel. So, _in this detector, the multithreading is so that each time-point is processed sequentially, and all the cores available are working on a single time-point_.

Also, if you can use ROIs to delineate multiple, sparse, regions to process, you will save on computation time and RAM, compared to processing the whole image.


_________

1. For a recent paper by him check Lindeberg, T. Image Matching Using Generalized Scale-Space Interest Points. J Math Imaging Vis 52, 3–36 (2015). https://doi.org/10.1007/s10851-014-0541-0

2. Mikolajczyk, K., Tuytelaars, T., Schmid, C. et al. A Comparison of Affine Region Detectors. Int J Comput Vision 65, 43–72 (2005). https://doi.org/10.1007/s11263-005-3848-x